### PR TITLE
Fix issue 304 (entering the command mode moves the window in pango)

### DIFF
--- a/yi/src/library/Yi/Tab.hs
+++ b/yi/src/library/Yi/Tab.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Yi.Tab where
+
+import Prelude()
+import Yi.Prelude
+import Data.Binary
+import Data.Typeable
+import qualified Data.List.PointedList as PL
+
+import Yi.Window
+
+type TabRef = Int
+
+-- | A tab, containing a collection of windows
+data Tab = Tab {
+  tkey :: !TabRef, -- ^ For UI sync; fixes #304
+  tabWindows :: !(PL.PointedList Window) -- ^ Visible windows
+  }
+ deriving Typeable
+
+tabWindowsA :: Accessor Tab (PL.PointedList Window)
+tabWindowsA = accessor tabWindows (\ws t -> t{tabWindows = ws})
+
+instance Binary Tab where
+  put (Tab tk ws) = put tk >> put ws
+  get = Tab <$> get <*> get
+
+instance Eq Tab where
+  (==) t1 t2 = tkey t1 == tkey t2
+
+instance Show Tab where
+  show t = "Tab " ++ show (tkey t)
+
+-- | A specialised version of "fmap".
+mapWindows :: (Window -> Window) -> Tab -> Tab
+mapWindows f (Tab tk ws) = Tab tk (fmap f ws)
+
+-- | Forces all windows in the tab
+forceTab :: Tab -> Tab
+forceTab (Tab tk ws) = foldr seq (Tab tk ws) ws
+
+-- | Folds over the windows in the tab
+tabFoldl :: (a -> Window -> a) -> a -> Tab -> a
+tabFoldl f z t = foldl f z (tabWindows t)
+

--- a/yi/src/library/Yi/UI/Pango/Control.hs
+++ b/yi/src/library/Yi/UI/Pango/Control.hs
@@ -42,6 +42,7 @@ import Yi.Prelude
 import Yi.Core (startEditor, focusAllSyntax)
 import Yi.Buffer
 import Yi.Config
+import Yi.Tab
 import Yi.Window as Yi
 import Yi.Editor
 import Yi.Event
@@ -95,7 +96,7 @@ data Control = Control
 --    }
 
 data TabInfo = TabInfo
-    { coreTab     :: PL.PointedList Yi.Window
+    { coreTab     :: Tab
 --    , page        :: VBox
     }
 
@@ -220,14 +221,14 @@ doLayout e = do
     cacheRef <- asks tabCache
     tabs <- liftIO $ readRef cacheRef
     heights <- concat <$> mapM (getHeightsInTab e) tabs
-    let e' = (tabsA ^: fmap (fmap updateWin)) e
+    let e' = (tabsA ^: fmap (mapWindows updateWin)) e
         updateWin w = case find (\(ref,_,_) -> (wkey w == ref)) heights of
                           Nothing -> w
                           Just (_,h,rgn) -> w { height = h, winRegion = rgn }
 
     -- Don't leak references to old Windows
     let forceWin x w = height w `seq` winRegion w `seq` x
-    return $ (foldl . foldl) forceWin e' (e' ^. tabsA)
+    return $ (foldl . tabFoldl) forceWin e' (e' ^. tabsA)
 
 getHeightsInTab :: Editor -> TabInfo -> ControlM [(WindowRef,Int,Region)]
 getHeightsInTab e tab = do
@@ -243,7 +244,7 @@ getHeightsInTab e tab = do
                 let ret= (windowRef v, round $ fromIntegral h / lineHeight, rgn)
                 return $ a ++ [ret]
             Nothing -> return a)
-      [] (coreTab tab)
+      [] (tabWindows $ coreTab tab)
 
 shownRegion :: Editor -> View -> FBuffer -> ControlM Region
 shownRegion e v b = do
@@ -299,7 +300,7 @@ updateCache e = do
     cache' <- syncTabs e (toList $ PL.withFocus tabs) cache
     liftIO $ writeRef cacheRef cache'
 
-syncTabs :: Editor -> [(PL.PointedList Yi.Window, Bool)] -> [TabInfo] -> ControlM [TabInfo]
+syncTabs :: Editor -> [(Tab, Bool)] -> [TabInfo] -> ControlM [TabInfo]
 syncTabs e (tfocused@(t,focused):ts) (c:cs)
     | t == coreTab c =
         do when focused $ setTabFocus c
@@ -318,7 +319,7 @@ syncTabs e ts [] = mapM (\(t,focused) -> do
         return c') ts
 syncTabs _ [] cs = mapM_ removeTab cs >> return []
 
-syncTab :: Editor -> TabInfo -> PL.PointedList Yi.Window -> ControlM TabInfo
+syncTab :: Editor -> TabInfo -> Tab -> ControlM TabInfo
 syncTab e tab ws = do
     -- TODO Maybe do something here
     return tab
@@ -356,13 +357,13 @@ removeView tab view = do
   return ()
 
 -- | Make a new tab.
-newTab :: Editor -> PL.PointedList Yi.Window -> ControlM TabInfo
+newTab :: Editor -> Tab -> ControlM TabInfo
 newTab e ws = do
     let t' = TabInfo { coreTab = ws }
 --    cache <- syncWindows e t' (toList $ PL.withFocus ws) []
     return t' -- { views = cache }
 
-insertTabBefore :: Editor -> PL.PointedList Yi.Window -> TabInfo -> ControlM TabInfo
+insertTabBefore :: Editor -> Tab -> TabInfo -> ControlM TabInfo
 insertTabBefore e ws c = do
     -- Just p <- notebookPageNum (uiNotebook ui) (page c)
     -- vb <- vBoxNew False 1
@@ -371,7 +372,7 @@ insertTabBefore e ws c = do
     t <- newTab e ws
     return t
 
-insertTab :: Editor -> PL.PointedList Yi.Window -> ControlM TabInfo
+insertTab :: Editor -> Tab -> ControlM TabInfo
 insertTab e ws = do
     -- vb <- vBoxNew False 1
     -- notebookAppendPage (uiNotebook ui) vb ""
@@ -575,7 +576,10 @@ newView buffer font = do
 
     tabsRef <- asks tabCache
     ts <- liftIO $ readRef tabsRef
-    liftIO $ writeRef tabsRef (TabInfo (PL.singleton newWindow):ts)
+    -- TODO: the Tab idkey should be assigned using
+    -- Yi.Editor.newRef. But we can't modify that here, since our
+    -- access to 'Yi' is readonly.
+    liftIO $ writeRef tabsRef (TabInfo (Tab 0 (PL.singleton newWindow)):ts)
 
     viewsRef <- asks views
     vs <- liftIO $ readRef viewsRef

--- a/yi/src/library/Yi/UI/TabBar.hs
+++ b/yi/src/library/Yi/UI/TabBar.hs
@@ -5,6 +5,7 @@ import qualified Data.List.PointedList.Circular as PL
 import System.FilePath
 
 import Yi.Buffer (shortIdentString)
+import Yi.Tab
 import Yi.Window
 import Yi.Editor (Editor(..)
                  ,commonNamePrefix
@@ -21,7 +22,7 @@ type TabBarDescr = PL.PointedList TabDescr
 tabBarDescr :: Editor -> TabBarDescr
 tabBarDescr editor = 
     let prefix = commonNamePrefix editor
-        hintForTab tab = tabAbbrevTitle $ shortIdentString prefix $ findBufferWith (bufkey $ PL.focus tab) editor
+        hintForTab tab = tabAbbrevTitle $ shortIdentString prefix $ findBufferWith (bufkey $ PL.focus (tabWindows tab)) editor
         tabDescr (tab,True) = TabDescr (hintForTab tab) True
         tabDescr (tab,False) = TabDescr (hintForTab tab) False
     in fmap tabDescr (PL.withFocus $ editor ^. tabsA)

--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -163,6 +163,7 @@ library
     Yi.Syntax.Paren
     Yi.Syntax.Tree
     Yi.Syntax.Strokes.Haskell
+    Yi.Tab
     Yi.Tag
     Yi.TextCompletion,
     Yi.UI.Common


### PR DESCRIPTION
Tabs now have unique keys for the purpose of synchronising with the UI, just like windows and buffers have.

(The code in Yi.UI.Pango.Control is wrong (see the TODO), but I am unwilling to change it because of the amount of changes that would be required, and also since it seems that Yi.UI.Pango is used in favor of Yi.UI.Pango.Control.)
