### PR TITLE
splitE if yi.errors needs to be displayed.

### DIFF
--- a/yi/src/library/Yi/Boot.hs
+++ b/yi/src/library/Yi/Boot.hs
@@ -20,7 +20,7 @@ realMain config = do
 
 showErrorsInConf :: Config -> String -> Config
 showErrorsInConf conf errs
-    = conf { initialActions = (makeAction $ newBufferE (Left "*errors*") (R.fromString errs)) : initialActions conf }
+    = conf { initialActions = (makeAction $ splitE >> newBufferE (Left "*errors*") (R.fromString errs)) : initialActions conf }
 
 yi, yiDriver :: Config -> IO ()
 


### PR DESCRIPTION
Previously, if yi.errors needed to be displayed and the user passed a fileame on the command line
the yi.errors' buffer would take the place of the file's buffer. So it'd appear as if the user's
request to open a file was ignored. With this patch, if yi.errors needs to be displayed, then the editor will display it in a split. 
