### PR TITLE
Fix issue 341: block comments in C lexer

### DIFF
--- a/yi/src/library/Yi/Lexer/C.x
+++ b/yi/src/library/Yi/Lexer/C.x
@@ -125,6 +125,7 @@ c :-
 
 <0> {
   "//"[^\n]*                                    { c commentStyle }
+  "/*".*"*/"                                    { c blockCommentStyle }
 
  "/*" @reservedop*                              { m (subtract 1) blockCommentStyle }
 


### PR DESCRIPTION
Added a rule to cover C block comments that end on the very same line.

See this bug report:
http://code.google.com/p/yi-editor/issues/detail?id=341
