### PR TITLE
Sort of fixing behaviour of # in normal vim mode

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim.hs
+++ b/yi/src/library/Yi/Keymap/Vim.hs
@@ -1628,8 +1628,12 @@ viFnewE f = discard (editFile $ dropSpace f)
 -- | viSearch is a doSearch wrapper that print the search outcome.
 -- TODO: consider merging with doSearch 
 viSearch :: String -> [SearchOption] -> Direction -> EditorM ()
-viSearch x y z = do
-  r <- doSearch (if null x then Nothing else Just x) y z
+viSearch needle searchOptions dir = do
+  r <- doSearch (if null needle then Nothing else Just needle) searchOptions dir
+  when (dir == Backward) $ do
+    -- move cursor so that it stands on the last character of search term
+    -- enabling user to continue searching with # or * after #
+    withBuffer0' $ viMove (CharMove Backward)
   case r of
     PatternFound    -> return ()
     PatternNotFound -> printMsg "Pattern not found"

--- a/yi/src/library/Yi/Search.hs
+++ b/yi/src/library/Yi/Search.hs
@@ -93,6 +93,7 @@ type SearchMatch = Region
 data SearchResult = PatternFound
                   | PatternNotFound
                   | SearchWrapped
+  deriving Eq
 
 doSearch :: Maybe String        -- ^ @Nothing@ means used previous
                                 -- pattern, if any. Complain otherwise.


### PR DESCRIPTION
In real vim, user can jump with # and \* as many times as he wants.
In yi, # leaves cursor just after the last character of search term, so that subsequent # and \* are not possible.

Example:

``` C
foo();
bar();
foo();
```

When jumping from one _foo_ to another with #, cursor ends up being on left paren, which is most probably not what user wants.

This commit changes cursor position after # by 1 character to the left, allowing subsequent jumping with # and *.

I'm not familiar enough with codebase to make # behaviour exactly like in vim (placing cursor at the beginning of search term)
