### PR TITLE
Add missing '[' and ']' vim text units.

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim.hs
+++ b/yi/src/library/Yi/Keymap/Vim.hs
@@ -961,6 +961,8 @@ defKeymap = Proto template
        ,('(',  unitDelimited '(' ')')
        ,(')',  unitDelimited '(' ')')
        ,('b',  unitDelimited '(' ')')
+       ,('[',  unitDelimited '[' ']')
+       ,(']',  unitDelimited '[' ']')
        ,('{',  unitDelimited '{' '}')
        ,('}',  unitDelimited '{' '}')
        ,('B',  unitDelimited '{' '}')


### PR DESCRIPTION
I've been missing `di[`
