### PR TITLE
Prevent vertical cursor motion in vim normal mode from forgetting column

### DIFF
--- a/yi/src/library/Yi/Buffer/HighLevel.hs
+++ b/yi/src/library/Yi/Buffer/HighLevel.hs
@@ -41,7 +41,9 @@ botB = moveTo =<< sizeB
 
 -- | Move left if on eol, but not on blank line
 leftOnEol :: BufferM ()
-leftOnEol = do
+-- @savingPrefCol@ is needed, because deep down @leftB@ contains @forgetPrefCol@
+-- which messes up vertical cursor motion in Vim normal mode
+leftOnEol = savingPrefCol $ do
         eol <- atEol
         sol <- atSol
         when (eol && not sol) leftB

--- a/yi/src/library/Yi/Buffer/Misc.hs
+++ b/yi/src/library/Yi/Buffer/Misc.hs
@@ -75,6 +75,7 @@ module Yi.Buffer.Misc
   , getModeLine
   , getPercent
   , setInserting
+  , savingPrefCol
   , forgetPreferCol
   , movingToPrefCol
   , getPrefCol


### PR DESCRIPTION
Consider text like this:

```
1234567
abcd
ijklmnopqrt
```

where cursor stands at '7'

Pressing `2j` brings cursor to 'o', which is expected.
Pressing `jj`, which should be equivalent to `2j`, brings cursor to 'l'.

Proposed patch fixes that.

It also exposes getPrefCol, which can be used in user-defined modeline, for example. That certainly helped while investigating the issue.
