### PR TITLE
Don't reset regex after successful incremental search.

### DIFF
--- a/yi/src/library/Yi/Search.hs
+++ b/yi/src/library/Yi/Search.hs
@@ -337,13 +337,12 @@ isearchEnd accept = do
   let (lastSearched,_,_) = head s
   let (_,p0,_) = last s
   historyFinishGen iSearch (return lastSearched)
-  resetRegexE
   if accept 
      then do withBuffer0 $ setSelectionMarkPointB $ regionStart p0 
              printMsg "Quit"
-     else withBuffer0 $ moveTo $ regionStart p0
-  
-  
+     else do resetRegexE
+             withBuffer0 $ moveTo $ regionStart p0
+
 
 -----------------
 -- Query-Replace


### PR DESCRIPTION
This allows subsequent searches with `n` in vim mode after incremental search is finished.
