### PR TITLE
Convenient yi executable profiling and forwarding of runtime system options

### DIFF
--- a/yi/src/library/Yi/Boot.hs
+++ b/yi/src/library/Yi/Boot.hs
@@ -54,7 +54,11 @@ yiDriver cfg = do
                             , Dyre.showError    = showErrorsInConf
                             , Dyre.configDir    = Just . getAppUserDataDirectory $ "yi"
                             , Dyre.hidePackages = ["mtl"]
-                            , Dyre.ghcOpts      = ["-threaded", "-O2"] ++ ghcOptions cfgcon
+                            , Dyre.ghcOpts      = (["-threaded", "-O2"] ++
+#ifdef PROFILING
+                                                   ["-prof", "-auto-all", "-rtsopts"] ++
+#endif
+                                                   ghcOptions cfgcon)
                             }
             in Dyre.wrapMain yiParams (finalCfg, cfgcon)
 

--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -54,6 +54,12 @@ flag ghcAPI
   --  * links against old version of Cabal
   -- ...
 
+flag profiling
+  Default: False
+  Description:
+    Runtime binary will be compiled with profiling and RTS
+    options enabled.
+
 flag hacking
   Default: False
   Description:
@@ -78,6 +84,9 @@ library
 
   if flag(hacking)
     buildable: False
+
+  if flag(profiling)
+    CPP-options: -DPROFILING
 
   exposed-modules:
     Yi
@@ -232,6 +241,10 @@ library
 
   build-tools: alex >= 3
   ghc-options: -Wall -fno-warn-orphans
+  ghc-prof-options: -prof -auto-all -rtsopts
+  if flag(profiling)
+    cpp-options: -DPROFILING
+
   if flag(hacking)
     ghc-prof-options: -prof -auto-all
 
@@ -369,6 +382,9 @@ executable yi
 
   if flag(dochack)
     buildable: False
+  
+  if flag(profiling)
+    cpp-options: -DPROFILING
 
   if flag(hacking)
     main-is: HackerMain.hs
@@ -381,3 +397,4 @@ executable yi
     build-depends: yi
   build-tools: alex >= 3
   ghc-options: -threaded
+  ghc-prof-options: -prof -auto-all -rtsopts


### PR DESCRIPTION
Note that one has to use compilation flags and patched Dyre with
rtsOptsHandling configuration parameter.

Compile with:

```
    cabal install --enable-library-profiling    \
                      --enable-executable-profiling \
                      --flags=profiling
```

RTS options will be automatically forwarded from main binary by Dyre.

Patched Dyre is on https://github.com/mgajda/dyre

Code will compile with old Dyre version (from Hackage now), but will not forward RTS options correctly in this case. (So that one has to use ~/.cache/yi/yi-\* binary directly to enable +RTS options.)
