### PR TITLE
Make file change polling on every refresh optional.

### DIFF
--- a/yi/src/library/Yi/Config.hs
+++ b/yi/src/library/Yi/Config.hs
@@ -66,6 +66,7 @@ data Config = Config {startFrontEnd :: UIBoot,
                       configKillringAccumulate :: Bool,
                       -- ^ Set to 'True' for an emacs-like behaviour, where 
                       -- all deleted text is accumulated in a killring.
+                      configCheckExternalChangesObsessively :: Bool,
                       bufferUpdateHandler :: [([Update] -> BufferM ())],
                       layoutManagers :: [AnyLayoutManager],
                       -- ^ List of layout managers for 'cycleLayoutManagersNext'

--- a/yi/src/library/Yi/Config/Default.hs
+++ b/yi/src/library/Yi/Config/Default.hs
@@ -174,6 +174,7 @@ defaultConfig =
                         AnyMode fundamentalMode]
          , debugMode = False
          , configKillringAccumulate = False
+         , configCheckExternalChangesObsessively = True
          , configRegionStyle = Exclusive
          , configInputPreprocess = I.idAutomaton
          , bufferUpdateHandler = []

--- a/yi/src/library/Yi/Core.hs
+++ b/yi/src/library/Yi/Core.hs
@@ -275,7 +275,7 @@ refreshEditor = onYiVar $ \yi var -> do
                 (if or relayout then UI.layout (yiUi yi) else return) e4
         
         e7 <- return (yiEditor var) >>= 
-             checkFileChanges >>= 
+             (if (configCheckExternalChangesObsessively cfg) then checkFileChanges else return) >>=
              pureM clearAllSyntaxAndHideSelection >>=
              -- Adjust window sizes according to UI info
              UI.layout (yiUi yi) >>=


### PR DESCRIPTION
Default behavior remains the same - poll file modification date on every refreshEditor call.

Now it's possible to disable it like that:

```
main :: IO ()
main = yi $ defaultVimConfig {
    configCheckExternalChangesObsessively = False
}
```
