### PR TITLE
Some Incremental search improvements

### DIFF
--- a/yi/src/library/Yi/Search.hs
+++ b/yi/src/library/Yi/Search.hs
@@ -345,9 +345,10 @@ iSearch = "isearch"
 isearchEnd :: Bool -> EditorM ()
 isearchEnd accept = do
   Isearch s <- getDynamic
-  let (lastSearched,_,_) = head s
+  let (lastSearched,_,dir) = head s
   let (_,p0,_) = last s
   historyFinishGen iSearch (return lastSearched)
+  putA searchDirectionA dir
   if accept 
      then do withBuffer0 $ setSelectionMarkPointB $ regionStart p0 
              printMsg "Quit"


### PR DESCRIPTION
1. Wrapping. No more failing i-search just because you didn't guess search direction.
2. After isearch is done, remember not only regex, but also direction for proper subsequent searches (e.g. with 'n' and 'N' in vim keymap)
