### PR TITLE
Some readline key bindings for ex mode.

### DIFF
--- a/yi/src/library/Yi/Keymap/Readline.hs
+++ b/yi/src/library/Yi/Keymap/Readline.hs
@@ -1,0 +1,21 @@
+module Yi.Keymap.Readline
+    ( standardMovementBindings
+    ) where
+
+import Yi.Buffer
+import Yi.Keymap
+import Yi.Keymap.Keys
+
+-- | Readline-like movement bindings intended for minibuffer keymaps
+standardMovementBindings :: Keymap
+standardMovementBindings =
+    choice [ ctrlCh 'b' ?>>! moveXorSol 1
+           , ctrlCh 'f' ?>>! moveXorEol 1
+           , metaCh 'b' ?>>! moveB unitWord Backward
+           , metaCh 'f' ?>>! moveB unitWord Forward
+           , spec KLeft  ?>>! moveXorSol 1
+           , spec KRight ?>>! moveXorEol 1
+           , ctrlCh 'a'  ?>>! moveToSol
+           , ctrlCh 'e'  ?>>! moveToEol
+           ]
+

--- a/yi/src/library/Yi/Keymap/Vim.hs
+++ b/yi/src/library/Yi/Keymap/Vim.hs
@@ -59,7 +59,7 @@ import System.PosixCompat.Files (fileExist)
 #else
 import System.Posix (fileExist)
 #endif
-import System.FilePath (FilePath, takeFileName)
+import System.FilePath (takeFileName)
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
 
 import Control.Monad.State hiding (mapM_, mapM, sequence)
@@ -83,6 +83,7 @@ import Yi.Tag
 import Yi.Window (bufkey)
 import Yi.Hoogle (hoogle, hoogleSearch)
 import qualified Codec.Binary.UTF8.String as UTF8
+import Yi.Keymap.Readline
 import Yi.Keymap.Vim.TagStack
 
 
@@ -1236,7 +1237,8 @@ exMode self prompt = do
                      ,spec KRight ?>>! moveXorEol 1
                      ,ctrlCh 'w'  ?>>! actionAndHistoryPrefix $ deleteB unitWord Backward
                      ,ctrlCh 'u'  ?>>! moveToSol >> deleteToEol]
-             <|| (insertChar >>! setHistoryPrefix)
+          <|| standardMovementBindings
+          <|| (insertChar >>! setHistoryPrefix)
       actionAndHistoryPrefix act = do
         discard $ withBuffer0 $ act
         setHistoryPrefix
@@ -1265,8 +1267,8 @@ exMode self prompt = do
                           fmap bufInfoFileName bufInfoB
 
                       let sanitizedFileName = case currentFileName of
-                                              ('/':'/':f) -> '/':f
-                                              otherwise -> currentFileName
+                                              ('/':'/':f') -> '/':f'
+                                              _ -> currentFileName
 
                       -- now modifying minibuffer
                       withBuffer $ do

--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -127,6 +127,7 @@ library
     Yi.Keymap.Emacs.KillRing
     Yi.Keymap.Emacs.Utils
     Yi.Keymap.Keys
+    Yi.Keymap.Readline
     Yi.Keymap.Vim
     Yi.Keymap.Vim.TagStack
     Yi.KillRing


### PR DESCRIPTION
Make C-a, C-e, C-b, C-f, M-b and M-f work in ex mode. Real vim doesn't do this, but it's nice to have.

Also fix a couple of warnings in Keymap/Vim.hs.
