### PR TITLE
Vim keymaps

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim.hs
+++ b/yi/src/library/Yi/Keymap/Vim.hs
@@ -679,9 +679,9 @@ defKeymap = Proto template
        w <- withBuffer0' $ readRegionB =<< regionOfNonEmptyB unitViWord
        viSearch (pattern bounded w) [] dir
        where
-         pattern bounded w = case bounded of
-                             Bounded   -> boundedPattern w
-                             Unbounded -> w
+         pattern bounded' w = case bounded' of
+             Bounded   -> boundedPattern w
+             Unbounded -> w
          boundedPattern x = "\\<" ++ (regexEscapeString x) ++ "\\>"
 
      gotoPrevTagMark :: Int -> YiM ()


### PR DESCRIPTION
Add vim key maps for `g*` and `g#`. Also, add an abbreviation of the `only` ex command.

I have tried to run the self-checks, but they don't seem to do anything.
`make test` complains about a UI not having been configured and exists so
quickly that I suspect that it is not running any tests. `dist/build/yi/yi
--self-check` opens up the editor and nothing appears to happen. Would you
explain where I'm going wrong in trying to run these?

Thanks
Ben Armston
