### PR TITLE
Workaround to prevent crashes with unicode chars.

### DIFF
--- a/yi/src/library/Yi/Lexer/common.hsinc
+++ b/yi/src/library/Yi/Lexer/common.hsinc
@@ -11,9 +11,17 @@ alexScanToken (AlexState state lookedOfs pos, inp@(_prevCh,str)) =
         lookedOfs' = max lookedOfs (posnOfs pos +~ Size lookahead) in
     case scn of
       AlexEOF -> Nothing
-      AlexError inp' ->
-        let errorHint = take 10 $ alexCollectChar inp'
-        in error $ "lexical error around " ++ errorHint
+
+      -- TODO: Get someone with sufficient understanding of Alex to look at this.
+      --
+      -- Currently we get here when buffer contains unicode char like umlauts or cyrillic.
+      -- Invoking error here made editor crash. So as a workaround we return Nothing.
+      -- This means that nothing after unicode char is highlighted,
+      -- but at least the editor remains working.
+      AlexError inp' -> Nothing
+        -- let msg = "lexical error around " ++ take 10 (alexCollectChar inp')
+        -- in error msg
+
       AlexSkip  inp' len  ->
         let chunk = take (fromIntegral len) str
         in alexScanToken (AlexState state lookedOfs' (moveStr pos chunk), inp')


### PR DESCRIPTION
I think it's better for users to have broken highlighting instead of broken editor.

Unfortunately, I don't know how to fix this properly. Tests in Alex itself seem to parse unicode without problems, so perhaps the problem is on our side.

Note that if you may have to run `cabal clean` before building yi with this patch, because cabal doesn't track common.hsinc dependencies.
