### PR TITLE
Adapt to new alex API

### DIFF
--- a/yi/src/library/Yi/Lexer/common.hsinc
+++ b/yi/src/library/Yi/Lexer/common.hsinc
@@ -69,16 +69,19 @@ alex_scan_tkn' user orig_input len input s last_acc =
           _ -> alex_scan_tkn' user orig_input new_len new_input new_s new_acc
 
   where
-    check_accs [] = last_acc
-    check_accs (AlexAcc a : _) = AlexLastAcc a input (I# len)
-    check_accs (AlexAccSkip : _)  = AlexLastSkip  input (I# len)
-    check_accs (AlexAccPred a pred : rest)
-       | pred user orig_input (I# len) input
-       = AlexLastAcc a input (I# len)
-    check_accs (AlexAccSkipPred pred : rest)
-       | pred user orig_input (I# len) input
-       = AlexLastSkip input (I# len)
-    check_accs (_ : rest) = check_accs rest
+	check_accs (AlexAccNone) = last_acc
+	check_accs (AlexAcc a  ) = AlexLastAcc a input (I# len)
+	check_accs (AlexAccSkip) = AlexLastSkip  input (I# len)
+	check_accs (AlexAccPred a predx rest)
+	   | predx user orig_input (I# len) input
+	   = AlexLastAcc a input (I# len)
+	   | otherwise
+	   = check_accs rest
+	check_accs (AlexAccSkipPred predx rest)
+	   | predx user orig_input (I# len) input
+	   = AlexLastSkip input (I# len)
+	   | otherwise
+	   = check_accs rest
 
 c = actionConst
 m = actionAndModify

--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -236,7 +236,7 @@ library
     unordered-containers >= 0.1.3 && < 0.3,
     xdg-basedir >= 0.2.1 && < 0.3
 
-  build-tools: alex >= 3
+  build-tools: alex >= 3.0.3
   ghc-options: -Wall -fno-warn-orphans
   ghc-prof-options: -prof -auto-all -rtsopts
   if flag(profiling)
@@ -399,6 +399,6 @@ executable yi
     base >=4 && <5
   if !flag(dochack)
     build-depends: yi
-  build-tools: alex >= 3
+  build-tools: alex >= 3.0.3
   ghc-options: -threaded
   ghc-prof-options: -prof -auto-all -rtsopts


### PR DESCRIPTION
Attached patch fixes yi build failure caused by https://github.com/simonmar/alex/commit/fe081e81bef6bda734829872ae6dcfc665ddb34b which took place between alex version 3.0.2 and 3.0.3

However, yi still fails to build with the following error:

```
[ 77 of 135] Compiling Yi.Lexer.Abella  ( dist/build/Yi/Lexer/Abella.hs, dist/build/Yi/Lexer/Abella.o )

src/library/Yi/Lexer/common.hsinc:76:21:
    Not in scope: data constructor `AlexAccPred'

src/library/Yi/Lexer/common.hsinc:81:21:
    Not in scope: data constructor `AlexAccSkipPred'
    Perhaps you meant `AlexAccSkip' (line 205)
```

As far as I can tell, this happens because alex chooses optimized "-nopred" template even when our lexers use predicates.

I've tried wrapping usage of AlexAccPred and AlexAccSkipPred in `#ifndef ALEX_NOPRED`, but that didn't change anything.

Currently yi can be built with `cabal install --alex-options="--debug"`, because this disables "-nopred" templates, so we get missing constructors back.

Out of curiosity I've tried to just remove any usage of AlexAccPred and AlexAccSkipPred from our code, but then yi crashes in runtime with message about non-exhaustive patterns.

I see two (and a half) possible solutions:
1) Yi should have two versions of Yi/Lexer/common.hsinc: with and without "-nopred". This will make lexer maintenance harder.
2) Alex should have an option disabling "-nopred" optimization.
2.5) I've screwed up with ALEX_NOPRED directive somehow and all this is easily fixable with an ifdef.
