### PR TITLE
ghciLoadBuffer error message improvement

### DIFF
--- a/yi/src/library/Yi/Mode/Haskell.hs
+++ b/yi/src/library/Yi/Mode/Haskell.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving
-           , Rank2Types, LambdaCase #-}
+           , Rank2Types #-}
 -- Copyright (c) 2008 Jean-Philippe Bernardy
 -- | Haskell-specific modes and commands.
 module Yi.Mode.Haskell
@@ -379,7 +379,8 @@ ghciSend cmd = do
 ghciLoadBuffer :: YiM ()
 ghciLoadBuffer = do
     fwriteE
-    withBuffer (gets file) >>= \case
+    f <- withBuffer (gets file)
+    case f of
       Nothing -> error "Couldn't get buffer filename in ghciLoadBuffer"
       Just filename -> ghciSend $ ":load " ++ filename
 


### PR DESCRIPTION
Previously calling ghciLoadBuffer in a buffer not bound to a filename would give us an unhelpful pattern match failure error. We now inform the user a bit better about what failed.

I remove trailing whitespace and a redundant import while I'm at it.
