### PR TITLE
Provide a much nicer file tab-completion

### DIFF
--- a/yi/src/library/Yi/Completion.hs
+++ b/yi/src/library/Yi/Completion.hs
@@ -70,7 +70,8 @@ completeInListCustomShow showFunction s match possibilities
     | prefix /= s = return prefix
     | isSingleton filtered = printMsg "Sole completion" >> return s
     | prefix `elem` filtered = printMsg ("Complete, but not unique: " ++ show filtered) >> return s
-    | otherwise = printMsgs (map showFunction filtered) >> return s
+    | otherwise = printMsgs (map showFunction filtered)
+                  >> return (bestMatch filtered s)
     where
       prefix   = commonPrefix filtered
       filtered = filterMatches match possibilities
@@ -80,9 +81,25 @@ completeInList' s match l
     | null filtered = printMsg "No match" >> return s
     | isSingleton filtered && s == (head filtered) = printMsg "Sole completion" >> return s
     | isSingleton filtered                         = return $ head filtered
-    | otherwise = printMsgs filtered >> return s
+    | otherwise = printMsgs filtered >> return (bestMatch filtered s)
     where
     filtered = filterMatches match l
+
+-- | This function attempts to provide a better tab completion result in
+-- cases where more than one file matches our prefix. Consider directory with
+-- following files: @["Main.hs", "Main.hi", "Main.o", "Test.py", "Foo.hs"]@.
+--
+-- After inserting @Mai@ into the minibuffer and attempting to complete, the
+-- possible matches will be filtered in 'completeInList'' to
+-- @["Main.hs", "Main.hi", "Main.o"]@ however because of multiple matches,
+-- the buffer will not be updated to say @Main.@ but will instead stay at @Mai@.
+--
+-- This is extremely tedious when trying to complete filenames in directories
+-- with many files so here we try to catch common prefixes of filtered files and
+-- if the result is longer than what we have, we use it instead.
+bestMatch :: [String] -> String -> String
+bestMatch fs s = let p = commonPrefix fs
+                 in if length p > length s then p else s
 
 filterMatches :: Eq a => (b -> Maybe a) -> [b] -> [a]
 filterMatches match = nub . catMaybes . fmap match
@@ -91,4 +108,3 @@ filterMatches match = nub . catMaybes . fmap match
 isSingleton :: [a] -> Bool
 isSingleton [_] = True
 isSingleton _   = False
-

--- a/yi/src/library/Yi/MiniBuffer.hs
+++ b/yi/src/library/Yi/MiniBuffer.hs
@@ -303,6 +303,3 @@ newtype CommandArguments = CommandArguments [String]
 instance Promptable CommandArguments where
     getPromptedValue = return . CommandArguments . words
     getPrompt _ = "Command arguments"
-
-
-

--- a/yi/src/library/Yi/Misc.hs
+++ b/yi/src/library/Yi/Misc.hs
@@ -125,14 +125,15 @@ adjIndent ib = withSyntaxB' (\m s -> modeIndent m s ib)
 
 
 
--- | Generic emacs style prompt file action. Takes a @prompt and a continuation @act
---   and prompts the user with file hints
+-- | Generic emacs style prompt file action. Takes a @prompt@ and a continuation
+-- @act@ and prompts the user with file hints
 promptFile :: String -> (String -> YiM ()) -> YiM ()
-promptFile prompt act = do maybePath <- withBuffer $ gets file
-                           startPath <- addTrailingPathSeparator <$> (liftIO $ canonicalizePath =<< getFolder maybePath)
-                           -- TODO: Just call withMinibuffer
-                           withMinibufferGen startPath (findFileHint startPath) prompt (completeFile startPath)
-                             (act . replaceShorthands)
+promptFile prompt act = do
+  maybePath <- withBuffer $ gets file
+  startPath <- addTrailingPathSeparator <$> (liftIO $ canonicalizePath =<< getFolder maybePath)
+  -- TODO: Just call withMinibuffer
+  withMinibufferGen startPath (findFileHint startPath) prompt (completeFile startPath)
+    (act . replaceShorthands)
 
 matchFile :: String -> String -> Maybe String
 matchFile path proposedCompletion =


### PR DESCRIPTION
See commit for closer description of the behaviour.

To re-iterate, we can now use tab-completion even on partial name matches rather than being restricted either the whole file name match or nothing at all.
