### PR TITLE
Fix normal mode command `C` on part of a line

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim2/NormalMap.hs
+++ b/yi/src/library/Yi/Keymap/Vim2/NormalMap.hs
@@ -198,7 +198,7 @@ nonrepeatableBindings = fmap (mkBindingE Normal Drop)
     -- Changing
     , (char 'C',
         do region <- withBuffer0 $ regionWithTwoMovesB (return ()) moveToEol
-           void $ operatorApplyToRegionE opDelete 1 $ StyledRegion Exclusive region
+           void $ operatorApplyToRegionE opChange 1 $ StyledRegion Exclusive region
         , switchMode $ Insert 'C')
     , (char 's', cutCharE Forward =<< getCountE, switchMode $ Insert 's')
     , (char 'S',

--- a/yi/src/tests/vimtests/change/C_part_of_line.test
+++ b/yi/src/tests/vimtests/change/C_part_of_line.test
@@ -1,0 +1,12 @@
+-- Input
+(1,9)
+Lorem ipsum dolor sit amet
+abc def ghi
+qwe rty uiop
+-- Output
+(1,11)
+Lorem ipman
+abc def ghi
+qwe rty uiop
+-- Events
+Cman<Esc>

--- a/yi/src/tests/vimtests/change/C_whole_line.test
+++ b/yi/src/tests/vimtests/change/C_whole_line.test
@@ -1,0 +1,12 @@
+-- Input
+(1,1)
+Lorem ipsum dolor sit amet
+abc def ghi
+qwe rty uiop
+-- Output
+(1,3)
+man
+abc def ghi
+qwe rty uiop
+-- Events
+Cman<Esc>

--- a/yi/src/tests/vimtests/change/S.test
+++ b/yi/src/tests/vimtests/change/S.test
@@ -1,0 +1,12 @@
+-- Input
+(1,11)
+Lorem ipsum dolor sit amet
+abc def ghi
+qwe rty uiop
+-- Output
+(1,3)
+man
+abc def ghi
+qwe rty uiop
+-- Events
+Sman<Esc>


### PR DESCRIPTION
Previously, when operating on part of a line, `C` would move the cursor one
char to the left. `C_part_of_line.test` is the test corrected by this change. The other two tests are to convince myself that I haven't introduced a regression.
