### PR TITLE
GHCi mode split off from Interactive mode

### DIFF
--- a/yi/src/library/Yi/Command.hs
+++ b/yi/src/library/Yi/Command.hs
@@ -109,7 +109,7 @@ cabalBuildE = cabalRun "build" (const $ return ())
 shell :: YiM BufferRef
 shell = do
     sh <- io shellFileName
-    Interactive.interactive sh ["-i"]
+    Interactive.spawnProcess sh ["-i"]
     -- use the -i option for interactive mode (assuming bash)
 
 -- | Search the source files in the project.

--- a/yi/src/library/Yi/Mode/Abella.hs
+++ b/yi/src/library/Yi/Mode/Abella.hs
@@ -95,7 +95,7 @@ abellaAbort = do abellaSend "abort."
 -- | Start Abella in a buffer
 abella :: CommandArguments -> YiM BufferRef
 abella (CommandArguments args) = do
-    b <- Interactive.interactive "abella" args
+    b <- Interactive.spawnProcess "abella" args
     withEditor . setDynamic . AbellaBuffer $ Just b
     return b
 

--- a/yi/src/library/Yi/Mode/GHCi.hs
+++ b/yi/src/library/Yi/Mode/GHCi.hs
@@ -1,0 +1,32 @@
+-- | a mode for GHCi, implemented as tweaks on Interaction mode
+module Yi.Mode.GHCi where
+
+import Control.Lens
+import Data.List (elemIndex)
+import Yi.Core
+import Yi.Lexer.Alex (Tok)
+import Yi.Lexer.Compilation (Token())
+import qualified Yi.Mode.Compilation as Compilation
+import qualified Yi.Syntax.OnlineTree as OnlineTree
+
+import qualified Yi.Mode.Interactive as I
+
+mode :: Mode (OnlineTree.Tree (Tok Token))
+mode = I.mode
+  { modeName = "ghci",
+    modeKeymap = modeKeymap I.mode . (topKeymapA %~ ((<||) (choice [spec KHome ?>>! homeKey])))
+  }
+
+-- | The GHCi prompt always begins with ">"; this goes to just before it, or if one is already at the start
+-- of the prompt, goes to the beginning of the line. (If at the beginning of the line, this pushes you forward to it.)
+homeKey :: BufferM ()
+homeKey = do l <- readLnB
+             let epos = elemIndex '>' l
+             case epos of
+                 Nothing -> moveToSol
+                 Just pos -> do (_,mypos) <- getLineAndCol
+                                if mypos == (pos+2) then moveToSol
+                                 else moveToSol >> moveXorEol (pos+2)
+
+spawnProcess :: FilePath -> [String] -> YiM BufferRef
+spawnProcess = I.spawnProcessMode mode

--- a/yi/src/library/Yi/Mode/Haskell.hs
+++ b/yi/src/library/Yi/Mode/Haskell.hs
@@ -41,6 +41,7 @@ import qualified Yi.IncrementalParse as IncrParser
 import qualified Yi.Lexer.Alex as Alex
 import qualified Yi.Lexer.LiterateHaskell as LiterateHaskell
 import Yi.Lexer.Haskell as Haskell
+import qualified Yi.Mode.GHCi as GHCi
 import qualified Yi.Mode.Interactive as Interactive
 import Yi.Modes (anyExtension, extensionOrContentsMatch)
 import Yi.MiniBuffer
@@ -358,7 +359,7 @@ instance YiVariable GhciBuffer
 -- | Start GHCi in a buffer
 ghci :: YiM BufferRef
 ghci = do
-    b <- Interactive.interactive "ghci" []
+    b <- GHCi.spawnProcess "ghci" []
     withEditor $ setDynamic $ GhciBuffer $ Just b
     return b
 

--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -198,6 +198,7 @@ library
     Yi.Mode.Abella
     Yi.Mode.Buffers
     Yi.Mode.Compilation
+    Yi.Mode.GHCi
     Yi.Mode.Haskell
     Yi.Mode.Haskell.Dollarify
     Yi.Mode.IReader


### PR DESCRIPTION
- `Interactive.Interactive` renamed `Interactive.spawnProcess`
- Haskell mode changed to use GHCI mode to for ghci
- `Yi.Mode.GHCi` added to cabal exposed modules list
