### PR TITLE
Improve compatibility for :buffer command and add tests for existing behaviour

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim2/Ex/Commands/Buffer.hs
+++ b/yi/src/library/Yi/Keymap/Vim2/Ex/Commands/Buffer.hs
@@ -18,7 +18,7 @@ import qualified Yi.Keymap.Vim2.Ex.Commands.Common as Common
 
 
 parse :: String -> Maybe ExCommand
-parse = Common.parseWithBang nameParser $ \ _ bang -> do
+parse = Common.parseWithBangAndCount nameParser $ \ _ bang mcount -> do
     bufIdent <- P.try ( P.many1 P.digit <|> bufferSymbol) <|>
                 P.many1 P.space *> P.many P.anyChar <|>
                 P.eof *> return ""
@@ -28,7 +28,9 @@ parse = Common.parseWithBang nameParser $ \ _ bang -> do
             unchanged <- withBuffer0 $ gets isUnchangedBuffer
             if bang || unchanged
                 then
-                    switchToBuffer bufIdent
+                    case mcount of
+                        Nothing -> switchToBuffer bufIdent
+                        Just i  -> switchByRef $ BufferRef i
                 else
                     Common.errorNoWrite
       }

--- a/yi/src/tests/Vim2/EditorManipulations/BufferExCommand.hs
+++ b/yi/src/tests/Vim2/EditorManipulations/BufferExCommand.hs
@@ -117,9 +117,57 @@ tests c ev =
             runTest setupActions preConditions testActions assertions c
 
 
-      -- , testCase "A modified buffer is not abandoned" $ do
-      -- , testCase "A modified buffer can be abandoned with a bang" $ do
-      -- , testCase "A buffer number can be given as a count" $ do
+      , testCase "A modified buffer is not abandoned" $ do
+            let setupActions = createInitialBuffers
+
+                preConditions editor buffers =
+                    assertNotCurrentBuffer (nthBufferRef 1 buffers) editor
+
+                testActions buffers = do
+                    withBuffer0 $ insertN "The buffer is altered"
+                    ev $ ":buffer " ++ nthBufferName 1 buffers ++ "<CR>"
+
+                assertions editor buffers = do
+                    assertNotCurrentBuffer (nthBufferRef 1 buffers) editor
+
+            runTest setupActions preConditions testActions assertions c
+
+
+      , testCase "A modified buffer can be abandoned with a bang" $ do
+            let setupActions = createInitialBuffers
+
+                preConditions editor buffers =
+                    assertNotCurrentBuffer (nthBufferRef 1 buffers) editor
+
+                testActions buffers = do
+                    withBuffer0 $ insertN "The buffer is altered"
+                    ev $ ":buffer! " ++ nthBufferName 1 buffers ++ "<CR>"
+
+                assertions editor buffers = do
+                    assertCurrentBuffer (nthBufferRef 1 buffers) editor
+
+            runTest setupActions preConditions testActions assertions c
+
+
+      , testCase ":Nbuffer switches to the numbered buffer" $ do
+            let setupActions = createInitialBuffers
+
+                preConditions editor buffers =
+                    assertNotCurrentBuffer (nthBufferRef 1 buffers) editor
+
+                testActions buffers =
+                    -- return ()
+                    let (BufferRef bref) = nthBufferRef 1 buffers
+                    in ev $ ":" ++ show bref ++ "buffer<CR>"
+                    -- in ev $ ":buffer " ++ show bref ++ "<CR>"
+
+                assertions editor buffers = do
+                    -- assertContentOfCurrentBuffer c "Buffer two" editor
+                    assertCurrentBuffer (nthBufferRef 1 buffers) editor
+
+            runTest setupActions preConditions testActions assertions c
+
+
       -- , testCase "A named buffer can be shown in a split window" $ do
       -- , testCase "A numbered buffer can be shown in a split window" $ do
     ]

--- a/yi/src/tests/Vim2/TestExCommandParsers.hs
+++ b/yi/src/tests/Vim2/TestExCommandParsers.hs
@@ -18,6 +18,7 @@ data CommandParser = CommandParser
     , cpParser      :: String -> Maybe ExCommand
     , cpNames       :: [String]
     , cpAcceptsBang :: Bool
+    , cpAcceptsCount :: Bool
     , cpArgs        :: Gen String
     }
 
@@ -70,6 +71,7 @@ commandParsers =
           Buffer.parse
           ["buffer", "buf", "bu", "b"]
           True
+          True
           bufferIdentifier
 
     , CommandParser
@@ -77,6 +79,7 @@ commandParsers =
           BufferDelete.parse
           ["bdelete", "bdel", "bd"]
           True
+          False
           (unwords <$> listOf bufferIdentifier)
 
     , CommandParser
@@ -87,6 +90,7 @@ commandParsers =
           -- :dl, :dell, :delel, :deletl, :deletel
           -- :dp, :dep, :delp, :delep, :deletp, :deletep
           True
+          False
           (oneof [ pure ""
                  , addingSpace registerName
                  , addingSpace count
@@ -101,8 +105,11 @@ commandString cp = do
     bang <- if cpAcceptsBang cp
                 then elements ["!", ""]
                 else pure ""
+    count' <- if cpAcceptsCount cp
+                then count
+                else pure ""
     args <- cpArgs cp
-    return $ concat [name, bang, args]
+    return $ concat [count', name, bang, args]
 
 
 expectedParserParses :: CommandParser -> TestTree


### PR DESCRIPTION
The `:buffer` command now
1. Behaves correctly when given a buffer reference of `%`, which is to do nothing.
2. Accepts the buffer command as a count.

I've also added tests for the functionality that was already there but not tested.
