### PR TITLE
Fix src paths in Makefile

### DIFF
--- a/yi/Makefile
+++ b/yi/Makefile
@@ -78,7 +78,7 @@ test-dist: sdist
 	cabal install &&\
 	cd ..;\
 
-HS := $(shell find src/Yi src/Shim src/Data -type f -name '[^.]*.hs') src/Yi.hs src/Main.hs
+HS := $(shell find src/library/Yi src/library/Shim src/library/Data -type f -name '[^.]*.hs') src/library/Yi.hs src/library/Main.hs
 tags: $(HS)
 	@ echo [tags]
 	@ echo '!_TAG_FILE_SORTED	0	~' > tags


### PR DESCRIPTION
I've tried `make build` right after cloning the repo and it seems that the paths in the `Makefile` were incorrect.

Maybe I'm missing something, though make works with this change :)
