### PR TITLE
Allow users to access GTK window

### DIFF
--- a/yi/src/library/Yi/UI/Common.hs
+++ b/yi/src/library/Yi/UI/Common.hs
@@ -3,6 +3,7 @@
 module Yi.UI.Common where
 
 import Yi.Editor
+import Graphics.UI.Gtk (Window)
 
 {- | Record presenting a frontend's interface.
 
@@ -53,6 +54,7 @@ data UI = UI
     , userForceRefresh      :: IO ()               -- ^ User force-refresh (in case the screen has been messed up from outside)
     , layout                :: Editor -> IO Editor -- ^ Set window width and height
     , reloadProject         :: FilePath -> IO ()   -- ^ Reload cabal project views
+    , gtkWindow             :: Maybe Window
     }
 
 dummyUI :: UI
@@ -64,4 +66,5 @@ dummyUI = UI
   , userForceRefresh = return ()
   , layout           = return
   , reloadProject    = const (return ())
+  , gtkWindow        = Nothing
   }

--- a/yi/src/library/Yi/UI/Pango.hs
+++ b/yi/src/library/Yi/UI/Pango.hs
@@ -135,6 +135,17 @@ mkUI ui = Common.dummyUI
     , Common.reloadProject = const reloadProject
     }
 
+mkUIGtk :: UI -> Gtk.Window -> Common.UI
+mkUIGtk ui win = Common.dummyUI
+    { Common.main          = main
+    , Common.end           = const end
+    , Common.suspend       = windowIconify (uiWindow ui)
+    , Common.refresh       = refresh ui
+    , Common.layout        = doLayout ui
+    , Common.reloadProject = const reloadProject
+    , Common.gtkWindow     = Just win
+    }
+
 updateFont :: UIConfig -> IORef FontDescription -> IORef TabCache -> Statusbar
                   -> FontDescription -> IO ()
 updateFont cfg fontRef tc status font = do
@@ -243,7 +254,7 @@ startNoMsgGtkHook userHook cfg ch outCh ed = do
   simpleNotebookOnSwitchPage (uiNotebook ui) $ \n -> postGUIAsync $
     runAction ((%=) tabsA (move n) :: EditorM ())
 
-  return (mkUI ui)
+  return (mkUIGtk ui win)
 
 
 main :: IO ()


### PR DESCRIPTION
`Yi.UI.Pango.startGtkHook` provides a way to access the GTK window. I'm unsure as to where to call the user's function, so it may need to be moved, possibly to after `timeoutAddFull`.
