### PR TITLE
Add travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yi
+# Yi [![Build Status](https://travis-ci.org/yi-editor/yi.svg?branch=master)](https://travis-ci.org/yi-editor/yi)
 
 Yi is a text editor written in Haskell and extensible in Haskell. The goal of Yi is to provide a flexible, powerful and correct editor core scriptable in Haskell.
 


### PR DESCRIPTION
The travis badge provides a quick way to view the build status and jump to the travis build result.
