### PR TITLE
For branch v0.8.2: Fixed dependency on lens such that it won't use more ...

### DIFF
--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -231,7 +231,7 @@ library
     concrete-typerep >= 0.1.0.2 && < 0.1.1,
     derive >=2.4 && <2.7,
     data-default,
-    lens >= 4.0,
+    lens >= 4.0 && <4.4,
     dlist >=0.4.1,
     dyre >=0.8.11,
     filepath>=1.1 && <1.4,


### PR DESCRIPTION
...recent versions of lens that it has incompatiblity (i.e. >=4.4).
