### PR TITLE
Remove Ref typeclass

### DIFF
--- a/yi/src/library/Yi/Core.hs
+++ b/yi/src/library/Yi/Core.hs
@@ -442,7 +442,7 @@ startSubprocessWatchers procid procinfo yi onExit =
       void $ onExit ec
 
 removeSubprocess :: SubprocessId -> YiM ()
-removeSubprocess procid = modifiesRef yiVar (yiSubprocessesA %~ M.delete procid)
+removeSubprocess procid = asks yiVar >>= liftBase . flip modifyMVar_ (pure . (yiSubprocessesA %~ M.delete procid))
 
 -- | Appends a 'R.YiString' to the given buffer.
 --
@@ -467,7 +467,7 @@ appendToBuffer atErr bufref s = withGivenBuffer0 bufref $ do
 sendToProcess :: BufferRef -> String -> YiM ()
 sendToProcess bufref s = do
     yi <- ask
-    find ((== bufref) . bufRef) . yiSubprocesses <$> readRef (yiVar yi) >>= \case
+    find ((== bufref) . bufRef) . yiSubprocesses <$> liftBase (readMVar (yiVar yi)) >>= \case
       Just subProcessInfo -> io $ hPutStr (hIn subProcessInfo) s
       Nothing -> msgEditor "Could not get subProcessInfo in sendToProcess"
 

--- a/yi/src/library/Yi/Monad.hs
+++ b/yi/src/library/Yi/Monad.hs
@@ -1,24 +1,15 @@
-{-# LANGUAGE FlexibleContexts #-}
 module Yi.Monad (
-                 Ref(..),
                  gets,
-                 -- uses,
                  getsAndModify,
                  maybeM,
-                 modifiesRef,
-                 modifiesThenReadsRef,
-                 readsRef,
                  repeatUntilM,
                  whenM,
                  with,
-                 writesRef
                 ) where
 
-import Data.IORef
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Base
-import Control.Concurrent.MVar
 
 -- | Combination of the Control.Monad.State 'modify' and 'gets'
 getsAndModify :: MonadState s m => (s -> (s,a)) -> m a
@@ -27,44 +18,6 @@ getsAndModify f = do
   let (e',result) = f e
   put e'
   return result
-
-class Ref ref where
-    readRef :: (MonadBase IO m) => ref a -> m a
-    writeRef :: (MonadBase IO m) => ref a -> a -> m ()
-    modifyRef :: (MonadBase IO m) => ref a -> (a -> a) -> m ()
-
-
-instance Ref IORef where
-    readRef r = liftBase $ readIORef r
-    writeRef r x = liftBase $ writeIORef r x
-    modifyRef r f = liftBase $ modifyIORef r f
-
-instance Ref MVar where
-    readRef r = liftBase $ readMVar r
-    writeRef r x = liftBase $ putMVar r x
-    modifyRef r f = liftBase $ modifyMVar_ r (return . f)
-
--- TODO: this store ref in MonadReader seems like an anti-pattern
-
-modifiesRef :: (Ref ref, MonadReader r m, MonadBase IO m) => (r -> ref a) -> (a -> a) -> m ()
-modifiesRef f g = do
-  b <- asks f
-  modifyRef b g
-
-readsRef :: (Ref ref, MonadReader r m, MonadBase IO m) => (r -> ref a) -> m a
-readsRef f = do
-  r <- asks f
-  readRef r
-
-writesRef :: (MonadReader r m, MonadBase IO m) => (r -> IORef a) -> a -> m ()
-writesRef f x = do
-  r <- asks f
-  writeRef r x
-
-modifiesThenReadsRef :: (MonadReader r m, MonadBase IO m) => (r -> IORef a) -> (a -> a) -> m a
-modifiesThenReadsRef f g = do
-  modifiesRef f g
-  readsRef f
 
 with :: (MonadReader r m, MonadBase b m) => (r -> a) -> (a -> b c) -> m c
 with f g = do
@@ -86,6 +39,3 @@ repeatUntilM m = do
     then (do xs <- repeatUntilM m 
              return (x:xs))
     else return [x]
-
--- uses :: MonadState s m => Accessor s p -> (p -> a) -> m a
--- uses a f = gets (f . getVal a)

--- a/yi/src/library/Yi/Types.hs
+++ b/yi/src/library/Yi/Types.hs
@@ -129,8 +129,8 @@ newtype YiM a = YiM {runYiM :: ReaderT Yi IO a}
     deriving (Monad, Applicative, MonadReader Yi, MonadBase IO, Typeable, Functor)
 
 instance MonadState Editor YiM where
-    get = yiEditor <$> (readRef =<< yiVar <$> ask)
-    put v = flip modifyRef (\x -> x {yiEditor = v}) =<< yiVar <$> ask
+    get = yiEditor <$> (liftBase . readMVar =<< yiVar <$> ask)
+    put v = liftBase . flip modifyMVar_ (\x -> return $ x {yiEditor = v}) =<< yiVar <$> ask
 
 instance MonadEditor YiM where
     askCfg = yiConfig <$> ask

--- a/yi/src/library/Yi/UI/Pango.hs
+++ b/yi/src/library/Yi/UI/Pango.hs
@@ -265,7 +265,7 @@ end = mainQuit
 -- | Modify GUI and the 'TabCache' to reflect information in 'Editor'.
 updateCache :: UI -> Editor -> IO ()
 updateCache ui e = do
-       cache <- readRef $ tabCache ui
+       cache <- readIORef $ tabCache ui
        -- convert to a map for convenient lookups
        let cacheMap = mapFromFoldable . fmap (\t -> (coreTabKey t, t)) $ cache
 
@@ -276,7 +276,7 @@ updateCache ui e = do
            Nothing -> newTab e ui tab
 
        -- store the new cache
-       writeRef (tabCache ui) cache'
+       writeIORef (tabCache ui) cache'
 
        -- update the GUI
        simpleNotebookSet (uiNotebook ui)
@@ -475,7 +475,7 @@ refresh ui e = do
          statusLine e
 
     updateCache ui e -- The cursor may have changed since doLayout
-    cache <- readRef $ tabCache ui
+    cache <- readIORef $ tabCache ui
     forM_ cache $ \t -> do
         wCache <- readIORef (windowCache t)
         forM_ wCache $ \w -> do
@@ -575,8 +575,8 @@ render ui w _event =
 doLayout :: UI -> Editor -> IO Editor
 doLayout ui e = do
     updateCache ui e
-    tabs <- readRef $ tabCache ui
-    f <- readRef (uiFont ui)
+    tabs <- readIORef $ tabCache ui
+    f <- readIORef (uiFont ui)
     heights <- fold <$> mapM (getHeightsInTab ui f e) tabs
     let e' = (tabsA %~ fmap (mapWindows updateWin)) e
         updateWin w = case M.lookup (wkey w) heights of


### PR DESCRIPTION
Mvar and IORef have different semantics (MVar can be empty, IORef can't), so this typeclass isn't all that useful. In addition, it's only used twice, and only to simplify using Reader MVar!
