### PR TITLE
Fix vim keymap for f<.

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim/Motion.hs
+++ b/yi/src/library/Yi/Keymap/Vim/Motion.hs
@@ -200,6 +200,7 @@ matchGotoMarkMove _ = NoMatch
 
 matchGotoCharMove :: String -> MatchResult Move
 matchGotoCharMove (m:[]) | m `elem` "fFtT" = PartialMatch
+matchGotoCharMove (m:"<lt>") | m `elem` "fFtT" = matchGotoCharMove (m:"<")
 matchGotoCharMove (m:c:[]) | m `elem` "fFtT" = WholeMatch $ Move style False action
     where (dir, style, move) =
               case m of

--- a/yi/src/tests/vimtests/find/f5.test
+++ b/yi/src/tests/vimtests/find/f5.test
@@ -1,0 +1,12 @@
+-- Input
+(1,1)
+Lorem ipsum dolor s<t amet
+abc def ghi
+qwe rty uiop
+-- Output
+(1,20)
+Lorem ipsum dolor s<t amet
+abc def ghi
+qwe rty uiop
+-- Events
+f<lt>


### PR DESCRIPTION
< comes in escaped as "<lt>", so it wasn't correctly pattern matching
for a single character.

Also adds test for this case.
