### PR TITLE
Fix vim write-as (:w ex command).

### DIFF
--- a/yi/src/library/Yi/Keymap/Vim/Ex/Commands/Write.hs
+++ b/yi/src/library/Yi/Keymap/Vim/Ex/Commands/Write.hs
@@ -23,14 +23,13 @@ import           Yi.Keymap.Vim.Ex.Types
 
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $
-               P.choice [parseWrite, parseWriteAs]
+               (P.try (P.string "w") <|> (P.string "write"))
+            *> (parseWriteAs <|> parseWrite)
     where parseWrite = do
-            void $ P.try ( P.string "write") <|> P.string "w"
             alls <- P.many (P.try ( P.string "all") <|> P.string "a")
             return $! writeCmd $ not (null alls)
 
           parseWriteAs = do
-            void $ P.try ( P.string "write") <|> P.string "w"
             void $ P.many1 P.space
             filename <- T.pack <$> P.many1 P.anyChar
             return $! writeAsCmd filename


### PR DESCRIPTION
Parser had two major flaws:
(1) It was using a nonbacktracking choice, both of which had the same
parser at the start. Factor this out.
(2) It was doing them in the wrong order, due to a the first essentially
unconditionally succeeding if :w or :write is present.
switched the order we try them, since the :w <file> demands a space.

Fixes #658 
