### PR TITLE
Reuse hint interpreter session

### DIFF
--- a/yi/yi.cabal
+++ b/yi/yi.cabal
@@ -286,7 +286,8 @@ library
     word-trie >= 0.2.0.4,
     yi-language >= 0.1.0.7,
     oo-prototypes,
-    yi-rope >= 0.6.0.0 && < 0.7
+    yi-rope >= 0.6.0.0 && < 0.7,
+    exceptions
 
   ghc-options: -Wall -fno-warn-orphans
   ghc-prof-options: -prof -auto-all -rtsopts


### PR DESCRIPTION
This makes evaluation of haskell code much faster, by leaving the hint interpreter running. Even if M-x is replaced by a static list of functions, I think it's still useful to be able to execute arbitrary haskell code, just as emacs has M-x and M-S-: to eval arbitrary lisp code.
