### PR TITLE
Proposal for our own HLint rules

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -3,4 +3,10 @@ import "hint" HLint.Builtin.All
 
 ignore "Eta reduce"
 
-error = x `mappend` y `mappend` z  ==> mconcat [x, y, z]
+error   "use mconcat"                            = x `mappend` y `mappend` z   ==> mconcat [x, y, z]
+warning "use concat"                             = x ++ y ++ z   ==> concat [x, y, z]
+warning "use fromMaybe"                          = \case {Nothing -> a; Just b -> b} ==> fromMaybe a
+error   "putEditorDynA works on any MonadEditor" = withEditor $ putEditorDynA a ==> putEditorDynA a
+error   "getEditorDynA works on any MonadEditor" = withEditor $ getEditorDynA a ==> getEditorDynA a
+error   "Why not use <$>?"                       = a          >>= return . b             ==> b <$> a
+error   "Why not use <$>?"                       = return . b =<< a                      ==> b <$> a


### PR DESCRIPTION
Since style discussions have gathered a lot of attention, I propose to expand the library of our own HLint style hints.

To use: `hlint --hint=HLint.hs src/library` and enjoy!

I believe there is Emacs mode that can automatically apply hints that you select.
