### PR TITLE
Typo

### DIFF
--- a/src/library/Yi/File.hs
+++ b/src/library/Yi/File.hs
@@ -104,7 +104,7 @@ revertE =
 viWrite :: YiM ()
 viWrite =
   withCurrentBuffer (gets file) >>= \case
-    Nothing -> errorEditor "no file name associate with buffer"
+    Nothing -> errorEditor "no file name associated with buffer"
     Just f  -> do
       bufInfo <- withCurrentBuffer bufInfoB
       let s   = bufInfoFileName bufInfo


### PR DESCRIPTION
Other error messages say "associated", not "associate".
Changed it to be "associated" in all cases.

PS: Apologies if requesting pulls to master is not correct. The README has no instructions on this point.