### PR TITLE
Fix issue #715

### DIFF
--- a/src/library/Yi/Main.hs
+++ b/src/library/Yi/Main.hs
@@ -112,7 +112,7 @@ versinfo = "yi " ++ display version
 do_args :: Config -> [String] -> Either Err (Config, ConsoleConfig)
 do_args cfg args =
     case getOpt (ReturnInOrder File) options args of
-        (os, [], []) -> foldM (getConfig shouldOpenInTabs) (cfg, defaultConsoleConfig) os
+        (os, [], []) -> foldM (getConfig shouldOpenInTabs) (cfg, defaultConsoleConfig) (reverse os)
         (_, _, errs) -> fail (concat errs)
     where
         shouldOpenInTabs = ("--" ++ openInTabsLong) `elem` args


### PR DESCRIPTION
Reverses the order of files in `System.Console.GetOpt`. I'm unable to reproduce the issue with duplicate files, so I'm guessing that magically got fixed somehow.