### PR TITLE
Fix build, and reuse functions

### DIFF
--- a/src/library/Parser/Incremental.hs
+++ b/src/library/Parser/Incremental.hs
@@ -17,18 +17,9 @@ module Parser.Incremental (Process,
                            evalL'
                           ) where
 
+import Control.Arrow       (first, second, (***))
 import Control.Applicative (Alternative ((<|>), empty), Applicative ((<*>), pure))
 import Data.Tree           (Tree (Node))
-
--- Local versions of our Control.Arrow friends (also make sure they are lazy enough)
-first :: forall t t1 t2. (t -> t2) -> (t, t1) -> (t2, t1)
-first f ~(a,b) = (f a,b)
-
-second :: forall t t1 t2. (t1 -> t2) -> (t, t1) -> (t, t2)
-second f ~(a,b) = (a,f b)
-
-(***) :: forall t t1 t2 t3. (t -> t2) -> (t1 -> t3) -> (t, t1) -> (t2, t3)
-(f *** g) ~(a,b) = (f a,g b)
 
 data a :< b = (:<) {top :: a, _rest :: b}
 infixr :<

--- a/src/library/Yi/Config/Default.hs
+++ b/src/library/Yi/Config/Default.hs
@@ -6,7 +6,7 @@ module Yi.Config.Default ( defaultConfig, availableFrontends, defaultEmacsConfig
                          , toEmacsStyleConfig, toCuaStyleConfig) where
 
 import           Control.Applicative
-import           Control.Lens
+import           Control.Lens        ((.~), (^.), use)
 import           Control.Monad
 import           Data.Default
 import qualified Data.HashMap.Strict as HM

--- a/src/library/Yi/Config/Simple.hs
+++ b/src/library/Yi/Config/Simple.hs
@@ -121,7 +121,7 @@ module Yi.Config.Simple (
  ) where
 
 import           Control.Applicative
-import           Control.Lens
+import           Control.Lens (Lens', (.=), (%=), (%~), use, lens)
 import           Control.Monad.State hiding (modify, get)
 import           Data.Maybe(mapMaybe)
 import qualified Data.Text as T


### PR DESCRIPTION
Fixes ambiguous occurrence of Yi.Keymap.Action (hiding Control.Lens.Action), and reuse functions from Control.Arrow for the incremental parser. To the best of my knowledge, the functions in Control.Arrow and Yi are equivalent. 