### PR TITLE
Vim: Fix behavior of character replace

### DIFF
--- a/src/tests/vimtests/change/s_eol.test
+++ b/src/tests/vimtests/change/s_eol.test
@@ -1,0 +1,12 @@
+-- Input
+(1,11)
+Lorem ipsum dolor sit amet
+abc def ghi
+qwe rty uiop
+-- Output
+(1,26)
+Lorem ipsum dolor sit amex
+abc def ghi
+qwe rty uiop
+-- Events
+$sx<Esc>


### PR DESCRIPTION
Fixes the behavior of 's' in NormalMap