### PR TITLE
Fixes #738 #610 / Yi.Keymap.Emacs (moveE)

### DIFF
--- a/src/library/Yi/Keymap/Emacs.hs
+++ b/src/library/Yi/Keymap/Emacs.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -93,14 +94,10 @@ deleteB' = adjBlock (-1) >> deleteN 1
 -- | Wrapper around 'moveE' which also cancels incremental search. See
 -- issue #499 for details.
 moveE :: TextUnit -> Direction -> EditorM ()
-moveE u d = do
-    maybeSearching <- getRegexE
-
-    case maybeSearching of -- let's check whether searching is in progress (issues #738, #610)
-        Nothing -> return ()
-        _ -> isearchFinishWithE resetRegexE
-
-    withCurrentBuffer (moveB u d)
+moveE u d = getRegexE >>= (\case -- let's check whether searching is in progress (issues #738, #610)
+                               Nothing -> return ()
+                               _ -> isearchFinishWithE resetRegexE)
+                      >> withCurrentBuffer (moveB u d)
 
 emacsKeys :: Maybe Int -> Keymap
 emacsKeys univArg =

--- a/src/library/Yi/Keymap/Emacs.hs
+++ b/src/library/Yi/Keymap/Emacs.hs
@@ -112,8 +112,8 @@ emacsKeys univArg =
          , spec KBS             ?>>! deleteRegionOr deleteBack
          , spec KHome           ?>>! repeatingArg moveToSol
          , spec KEnd            ?>>! repeatingArg moveToEol
-         , spec KLeft           ?>>! repeatingArg $ moveE Character Backward -- leftB
-         , spec KRight          ?>>! repeatingArg $ moveE Character Forward -- rightB
+         , spec KLeft           ?>>! repeatingArg $ moveE Character Backward
+         , spec KRight          ?>>! repeatingArg $ moveE Character Forward
          , spec KUp             ?>>! repeatingArg $ moveE VLine Backward
          , spec KDown           ?>>! repeatingArg $ moveE VLine Forward
          , spec KPageDown       ?>>! repeatingArg downScreenB
@@ -136,10 +136,10 @@ emacsKeys univArg =
          , ctrlCh '/'           ?>>! repeatingArg undoB
          , ctrlCh '_'           ?>>! repeatingArg undoB
          , ctrlCh 'a'           ?>>! repeatingArg (maybeMoveB Line Backward)
-         , ctrlCh 'b'           ?>>! repeatingArg $ moveE Character Backward -- leftB
+         , ctrlCh 'b'           ?>>! repeatingArg $ moveE Character Backward
          , ctrlCh 'd'           ?>>! deleteForward
          , ctrlCh 'e'           ?>>! repeatingArg (maybeMoveB Line Forward)
-         , ctrlCh 'f'           ?>>! repeatingArg $ moveE Character Forward -- rightB
+         , ctrlCh 'f'           ?>>! repeatingArg $ moveE Character Forward
          , ctrlCh 'g'           ?>>! setVisibleSelection False
          , ctrlCh 'h'           ?>> char 'b' ?>>! acceptedInputsOtherWindow
          , ctrlCh 'i'           ?>>! adjIndent IncreaseOnly

--- a/src/library/Yi/Keymap/Emacs.hs
+++ b/src/library/Yi/Keymap/Emacs.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeOperators     #-}
-{-# LANGUAGE UnicodeSyntax     #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -48,7 +47,7 @@ import Yi.MiniBuffer
 import Yi.Misc                  (adjBlock, adjIndent, placeMark, selectAll)
 import Yi.Mode.Buffers          (listBuffers)
 import Yi.Rectangle
-import Yi.Search                (isearchFinishWithE, resetRegexE)
+import Yi.Search                (isearchFinishWithE, resetRegexE, getRegexE)
 import Yi.TextCompletion        (resetComplete, wordComplete')
 
 data ModeMap = ModeMap { _eKeymap :: Keymap
@@ -93,8 +92,15 @@ deleteB' = adjBlock (-1) >> deleteN 1
 
 -- | Wrapper around 'moveE' which also cancels incremental search. See
 -- issue #499 for details.
-moveE ∷ TextUnit → Direction → EditorM ()
-moveE u d = isearchFinishWithE resetRegexE >> withCurrentBuffer (moveB u d)
+moveE :: TextUnit -> Direction -> EditorM ()
+moveE u d = do
+    maybeSearching <- getRegexE
+
+    case maybeSearching of -- let's check whether searching is in progress (issues #738, #610)
+        Nothing -> return ()
+        _ -> isearchFinishWithE resetRegexE
+
+    withCurrentBuffer (moveB u d)
 
 emacsKeys :: Maybe Int -> Keymap
 emacsKeys univArg =
@@ -106,8 +112,8 @@ emacsKeys univArg =
          , spec KBS             ?>>! deleteRegionOr deleteBack
          , spec KHome           ?>>! repeatingArg moveToSol
          , spec KEnd            ?>>! repeatingArg moveToEol
-         , spec KLeft           ?>>! repeatingArg leftB
-         , spec KRight          ?>>! repeatingArg rightB
+         , spec KLeft           ?>>! repeatingArg $ moveE Character Backward -- leftB
+         , spec KRight          ?>>! repeatingArg $ moveE Character Forward -- rightB
          , spec KUp             ?>>! repeatingArg $ moveE VLine Backward
          , spec KDown           ?>>! repeatingArg $ moveE VLine Forward
          , spec KPageDown       ?>>! repeatingArg downScreenB
@@ -130,10 +136,10 @@ emacsKeys univArg =
          , ctrlCh '/'           ?>>! repeatingArg undoB
          , ctrlCh '_'           ?>>! repeatingArg undoB
          , ctrlCh 'a'           ?>>! repeatingArg (maybeMoveB Line Backward)
-         , ctrlCh 'b'           ?>>! repeatingArg leftB
+         , ctrlCh 'b'           ?>>! repeatingArg $ moveE Character Backward -- leftB
          , ctrlCh 'd'           ?>>! deleteForward
          , ctrlCh 'e'           ?>>! repeatingArg (maybeMoveB Line Forward)
-         , ctrlCh 'f'           ?>>! repeatingArg rightB
+         , ctrlCh 'f'           ?>>! repeatingArg $ moveE Character Forward -- rightB
          , ctrlCh 'g'           ?>>! setVisibleSelection False
          , ctrlCh 'h'           ?>> char 'b' ?>>! acceptedInputsOtherWindow
          , ctrlCh 'i'           ?>>! adjIndent IncreaseOnly

--- a/src/library/Yi/Search.hs
+++ b/src/library/Yi/Search.hs
@@ -387,7 +387,6 @@ isearchEndWith act accept = getEditorDyn >>= \case
     assign searchDirectionA dir
     if accept
        then do void act
-               withCurrentBuffer $ setSelectionMarkPointB $ regionStart p0
                printMsg "Quit"
        else do resetRegexE
                withCurrentBuffer $ moveTo $ regionStart p0


### PR DESCRIPTION
Checks isearching before trying to finish it.
Before the fix, `moveE` always tried to `isearchFinishWithE`, which made `setSelectionMarkPointB $ regionStart p0` (Yi/Search.hs:390) and broke selection.

Although the problem has been localized and fixed here, there is the second place where the problem might show itself: https://github.com/yi-editor/yi/blob/master/src/library/Yi/Search.hs#L390
I'm not a vim user, that's why I suppose that this selection marking might be there for vim mode, but it makes the corruption of emacs's mode selection when isearch is being stopped.