### PR TITLE
#581 / Emacs mode M-r implementation

### DIFF
--- a/src/library/Yi/Buffer/HighLevel.hs
+++ b/src/library/Yi/Buffer/HighLevel.hs
@@ -150,25 +150,10 @@ import           Yi.Window                (Window (actualLines, height, width, w
 -- else it'll be gone to the middle
 moveToMTB :: BufferM ()
 moveToMTB = (==) <$> curLn <*> screenMidLn >>= \case
-    True -> moveToTopOfScreenB
+    True -> downFromTosB 0
     _    -> (==) <$> curLn <*> screenTopLn >>= \case
-                True -> moveToBottomOfScreenB
-                _    -> moveToMiddleOfScreenB
-
-
--- | Move point to the bottom of the screen
-moveToBottomOfScreenB :: BufferM ()
-moveToBottomOfScreenB = moveToTopOfScreenB >> (-) <$> screenBotLn <*> screenTopLn >>= flip replicateM_ lineDown
-
-
--- | Move point to the middle of the screen
-moveToMiddleOfScreenB :: BufferM ()
-moveToMiddleOfScreenB = moveToTopOfScreenB >> (-) <$> screenMidLn <*> screenTopLn >>= flip replicateM_ lineDown
-
-
--- | Move point to the top of the screen
-moveToTopOfScreenB ::BufferM ()
-moveToTopOfScreenB = moveTo =<< use . markPointA =<< fromMark <$> askMarks
+                True -> upFromBosB 0
+                _    -> downFromTosB =<< (-) <$> screenMidLn <*> screenTopLn
 
 
 -- | Move point to start of line

--- a/src/library/Yi/Buffer/Misc.hs
+++ b/src/library/Yi/Buffer/Misc.hs
@@ -35,6 +35,9 @@ module Yi.Buffer.Misc
   , runBuffer
   , runBufferFull
   , runBufferDummyWindow
+  , screenTopLn
+  , screenMidLn
+  , screenBotLn
   , curLn
   , curCol
   , colOf
@@ -191,7 +194,7 @@ module Yi.Buffer.Misc
 
 import           Prelude                        hiding (foldr, mapM, notElem)
 
-import           Control.Applicative            (Applicative ((*>), (<*>)), (<$>))
+import           Control.Applicative            (Applicative ((*>), (<*>), pure), (<$>))
 import           Control.Lens                   (Lens', assign, lens, use, uses, view, (%=), (%~), (.=), (^.))
 import           Control.Monad.RWS.Strict       (Endo (Endo, appEndo),
                                                  MonadReader (ask), MonadState,
@@ -225,7 +228,7 @@ import qualified Yi.Rope                        as R
 import           Yi.Syntax                      (ExtHL (ExtHL), Stroke, noHighlighter)
 import           Yi.Types
 import           Yi.Utils                       (SemiNum ((+~)), makeClassyWithSuffix, makeLensesWithSuffix)
-import           Yi.Window                      (Window (width, wkey), dummyWindow)
+import           Yi.Window                      (Window (width, wkey, actualLines), dummyWindow)
 
 
 -- In addition to Buffer's text, this manages (among others):
@@ -733,6 +736,29 @@ curLn :: BufferM Int
 curLn = do
     p <- pointB
     queryBuffer (lineAt p)
+
+
+-- | Top line of the screen
+screenTopLn :: BufferM Int
+screenTopLn = do
+    p <- use . markPointA =<< fromMark <$> askMarks
+    queryBuffer (lineAt p)
+
+
+-- | Middle line of the screen
+screenMidLn :: BufferM Int
+screenMidLn = (+) <$> screenTopLn <*> (div <$> screenLines <*> pure 2)
+
+
+-- | Bottom line of the screen
+screenBotLn :: BufferM Int
+screenBotLn = (+) <$> screenTopLn <*> screenLines
+
+
+-- | Amount of lines in the screen
+screenLines :: BufferM Int
+screenLines = pred <$> askWindow actualLines
+
 
 -- | Return line numbers of marks
 markLines :: BufferM (MarkSet Int)

--- a/src/library/Yi/Keymap/Emacs.hs
+++ b/src/library/Yi/Keymap/Emacs.hs
@@ -196,6 +196,7 @@ emacsKeys univArg =
          , metaCh 'l'           ?>>! repeatingArg lowercaseWordB
          , metaCh 'm'           ?>>! firstNonSpaceB
          , metaCh 'q'           ?>>! withSyntax modePrettify
+         , metaCh 'r'           ?>>! repeatingArg moveToMTB
          , metaCh 'u'           ?>>! repeatingArg uppercaseWordB
          , metaCh 't'           ?>>! repeatingArg (transposeB unitWord Forward)
          , metaCh 'w'           ?>>! killRingSaveE


### PR DESCRIPTION
Issue #581 / Missing Emacs bindings
In the brach the bind M-r in Yi.Keymap.Emacs has been made. Also several functions have been implemented (and exported): 
```
Yi.Buffer.HighLevel (moveToMTB)
Yi.Buffer.Misc (screenTopLn, screenMidLn, screenBotLn)
```
