### PR TITLE
Migrate from regex-tdfa to text-icu

### DIFF
--- a/src/library/Yi/Dired.hs
+++ b/src/library/Yi/Dired.hs
@@ -261,9 +261,9 @@ editFile filename = do
           rx = ICU.regex [] "\\-\\*\\- *([^ ]*) *\\-\\*\\-"
           hmode = case ICU.find rx (R.toText header) of
               Nothing -> ""
-              Just m  -> case (ICU.unfold ICU.group m) of
-                           [_, n] -> n
-                           _      -> ""
+              Just m  -> case (ICU.group 1 m) of
+                           Just n  -> n
+                           Nothing -> ""
           Just mode = find (\(AnyMode m) -> modeName m == hmode) tbl <|>
                       find (\(AnyMode m) -> modeApplies m f header) tbl <|>
                       Just (AnyMode emptyMode)

--- a/src/library/Yi/Modes.hs
+++ b/src/library/Yi/Modes.hs
@@ -236,8 +236,10 @@ anyExtension extensions fileName _contents
 -- a 'Mode.modeApplies' function.
 extensionOrContentsMatch :: [String] -> T.Text -> FilePath -> R.YiString -> Bool
 extensionOrContentsMatch extensions pattern fileName contents
-    = extensionMatches extensions fileName || contentsMatch contents
-    where contentsMatch = isJust . ICU.find (ICU.regex [] pattern) . R.toText
+    = extensionMatches extensions fileName || isJust m
+    where
+        r = ICU.regex [] pattern
+        m = ICU.find r $ R.toText contents
 
 -- | Adds a hook to all matching hooks in a list
 hookModes :: (AnyMode -> Bool) -> BufferM () -> [AnyMode] -> [AnyMode]

--- a/src/library/Yi/Rectangle.hs
+++ b/src/library/Yi/Rectangle.hs
@@ -30,9 +30,9 @@ alignRegion str = do
   modifyRegionB (R.fromText . alignText str . R.toText) s
   where
     regexSplit :: T.Text -> T.Text -> [T.Text]
-    regexSplit r l = case ICU.find (ICU.regex [] r) l of
-      Just m  -> drop 1 $ ICU.unfold ICU.group m
-      Nothing -> error "regexSplit: text does not match"
+    regexSplit pattern l = case ICU.find (ICU.regex [] pattern) l of
+        Nothing -> error "regexSplit: text does not match"
+        Just m  -> drop 1 $ ICU.unfold ICU.group m
 
     alignText :: T.Text -> T.Text -> T.Text
     alignText regex text = unlines' ls'

--- a/src/library/Yi/UI/Pango.hs
+++ b/src/library/Yi/UI/Pango.hs
@@ -23,7 +23,7 @@ module Yi.UI.Pango (start, startGtkHook) where
 import           Control.Applicative
 import           Control.Concurrent
 import           Control.Exception (catch, SomeException)
-import           Control.Lens hiding (set, Action, from)
+import           Control.Lens hiding (set, from)
 import           Control.Monad hiding (forM_, mapM_, forM, mapM)
 import           Data.Foldable
 import           Data.IORef

--- a/yi.cabal
+++ b/yi.cabal
@@ -281,8 +281,6 @@ library
     mtl >= 0.1.0.1,
     parsec >= 3.0,
     pointedlist >= 0.5,
-    regex-base ==0.93.*,
-    regex-tdfa >= 1.1 && <1.3,
     text-icu >= 0.7,
     safe >= 0.3.4 && < 0.4,
     split >= 0.1 && < 0.3,

--- a/yi.cabal
+++ b/yi.cabal
@@ -273,7 +273,7 @@ library
     bytestring >= 0.9.1 && < 0.11,
     dynamic-state >= 0.1.0.5,
     data-default,
-    lens >= 4.4.0.1,
+    lens >= 4.7,
     dlist >=0.4.1,
     dyre >=0.8.11,
     filepath >= 1.1,
@@ -283,6 +283,7 @@ library
     pointedlist >= 0.5,
     regex-base ==0.93.*,
     regex-tdfa >= 1.1 && <1.3,
+    text-icu >= 0.7,
     safe >= 0.3.4 && < 0.4,
     split >= 0.1 && < 0.3,
     template-haskell >= 2.4,
@@ -391,7 +392,7 @@ Test-Suite test-suite
     Vim.TestPureEditorManipulations
   build-depends:
     base,
-    lens >= 4.4.0.1,
+    lens >= 4.7,
     semigroups,
     tasty,
     tasty-hunit,


### PR DESCRIPTION
This mostly just rebases https://github.com/yi-editor/yi/pull/717 onto current master. Additionally, I've bumped up the minimum lens version, and replaced references to Yi.Regex in Dired to use Data.Text.ICU