### PR TITLE
Make sticky eol local to buffer.

### DIFF
--- a/src/library/Yi/Buffer/HighLevel.hs
+++ b/src/library/Yi/Buffer/HighLevel.hs
@@ -1165,7 +1165,6 @@ lineMoveVisRelDown n | n < 0 = lineMoveVisRelUp $ negate n
                 moveToEol
                 lineMoveVisRelDown $ next - 1
 
-
 -- | Implements the same logic that emacs' `mark-word` does.
 -- Checks the mark point and moves it forth (or backward) for one word.
 markWord :: BufferM ()

--- a/src/library/Yi/Buffer/Misc.hs
+++ b/src/library/Yi/Buffer/Misc.hs
@@ -192,6 +192,7 @@ module Yi.Buffer.Misc
   , indentSettingsB
   , fontsizeVariationA
   , encodingConverterNameA
+  , stickyEolA
   ) where
 
 import           Prelude                        hiding (foldr, mapM, notElem)
@@ -590,6 +591,7 @@ newB unique nm s =
             , undos  = emptyU
             , preferCol = Nothing
             , preferVisCol = Nothing
+            , stickyEol = False
             , bufferDynamic = mempty
             , pendingUpdates = []
             , selectionStyle = SelectionStyle False False

--- a/src/library/Yi/Keymap/Vim/Common.hs
+++ b/src/library/Yi/Keymap/Vim/Common.hs
@@ -128,7 +128,6 @@ data VimState = VimState
     , vsActiveRegister        :: !RegisterName
     , vsRepeatableAction      :: !(Maybe RepeatableAction)
     , vsStringToEval          :: !EventString -- ^ see Yi.Keymap.Vim.vimEval comment
-    , vsStickyEol             :: !Bool -- ^ is set on $, allows j and k walk the right edge of lines
     , vsOngoingInsertEvents   :: !EventString
     , vsLastGotoCharCommand   :: !(Maybe GotoCharCommand)
     , vsBindingAccumulator    :: !EventString
@@ -156,7 +155,6 @@ instance Default VimState where
             '\0' -- active register
             Nothing -- repeatable action
             mempty -- string to eval
-            False -- sticky eol
             mempty -- ongoing insert events
             Nothing -- last goto char command
             mempty -- binding accumulator

--- a/src/library/Yi/Keymap/Vim/NormalMap.hs
+++ b/src/library/Yi/Keymap/Vim/NormalMap.hs
@@ -105,7 +105,7 @@ zeroBinding = VimBindingE f
                   Nothing -> do
                       withCurrentBuffer moveToSol
                       resetCountE
-                      setStickyEolE False
+                      withCurrentBuffer $ stickyEolA .= False
                       return Drop
           f _ _ = NoMatch
 

--- a/src/library/Yi/Keymap/Vim/StateUtils.hs
+++ b/src/library/Yi/Keymap/Vim/StateUtils.hs
@@ -27,7 +27,6 @@ module Yi.Keymap.Vim.StateUtils
     , setRegisterE
     , getRegisterE
     , normalizeCountE
-    , setStickyEolE
     , maybeMult
     , updateModeIndicatorE
     , saveInsertEventStringE
@@ -140,9 +139,6 @@ maybeMult (Just a) (Just b) = Just (a * b)
 maybeMult Nothing  Nothing = Nothing
 maybeMult a        Nothing = a
 maybeMult Nothing  b       = b
-
-setStickyEolE :: Bool -> EditorM ()
-setStickyEolE b = modifyStateE $ \s -> s { vsStickyEol = b }
 
 updateModeIndicatorE :: VimState -> EditorM ()
 updateModeIndicatorE prevState = do

--- a/src/library/Yi/Keymap/Vim/VisualMap.hs
+++ b/src/library/Yi/Keymap/Vim/VisualMap.hs
@@ -80,7 +80,7 @@ zeroBinding = VimBindingE f
                   Nothing -> do
                       withCurrentBuffer moveToSol
                       resetCountE
-                      setStickyEolE False
+                      withCurrentBuffer $ stickyEolA .= False
                       return Continue
           f _ _ = NoMatch
 

--- a/src/library/Yi/Types.hs
+++ b/src/library/Yi/Types.hs
@@ -216,6 +216,8 @@ data Attributes
     -- ^ prefered column to arrive at when we do a lineDown / lineUp
     , preferVisCol :: !(Maybe Int)
     -- ^ prefered column to arrive at visually (ie, respecting wrap)
+    , stickyEol :: !Bool
+    -- ^ stick to the end of line (used by vim bindings mostly)
     , pendingUpdates :: ![UIUpdate]
     -- ^ updates that haven't been synched in the UI yet
     , selectionStyle :: !SelectionStyle
@@ -238,14 +240,14 @@ data Attributes
 
 
 instance Binary Yi.Types.Attributes where
-    put (Yi.Types.Attributes n b u bd pc pv pu selectionStyle_
+    put (Yi.Types.Attributes n b u bd pc pv se pu selectionStyle_
          _proc wm law lst ro ins _dc _pfw isTransacPresent transacAccum fv cn) = do
       let putTime (UTCTime x y) = B.put (fromEnum x) >> B.put (fromEnum y)
       B.put n >> B.put b >> B.put u >> B.put bd
-      B.put pc >> B.put pv >> B.put pu >> B.put selectionStyle_ >> B.put wm
+      B.put pc >> B.put pv >> B.put se >> B.put pu >> B.put selectionStyle_ >> B.put wm
       B.put law >> putTime lst >> B.put ro >> B.put ins >> B.put _dc
       B.put isTransacPresent >> B.put transacAccum >> B.put fv >> B.put cn
-    get = Yi.Types.Attributes <$> B.get <*> B.get <*> B.get <*>
+    get = Yi.Types.Attributes <$> B.get <*> B.get <*> B.get <*> B.get <*>
           B.get <*> B.get <*> B.get <*> B.get <*> B.get <*> pure I.End <*> B.get <*> B.get
           <*> getTime <*> B.get <*> B.get <*> B.get
           <*> pure (const False) <*> B.get <*> B.get <*> B.get <*> B.get


### PR DESCRIPTION
Useful for fixing #773 

Many of our BufferM functions need to be aware of sticky eols
when dealing with block-style regions. Instead of converting
all of those to EditorM, it makes sense to annotate the buffer
with whether or not sticky eol is enabled.

Sticky eol will never be enabled in the emacs map, and the vim
map now uses the BufferM sticky eol instead of the one internal
to its own state.

To be honest, I'm not sure if moving it to be buffer-local breaks
vim compatibility or not, but it seems to *me* that it should be
local to the buffer and not the editor. And, as mentioned, this is
needed for region-based functions to properly function without
needing this passed in constantly...

This just needs to be sanity checked and then I can merge it if
nobody sees any major issues