### PR TITLE
Yi/Editor.hs: Fix build failure

### DIFF
--- a/src/library/Yi/Editor.hs
+++ b/src/library/Yi/Editor.hs
@@ -613,7 +613,7 @@ focusWindowE k = do
         searchWindowSet r@(True, _, _) _ws = r
 
     case foldl searchWindowSet  (False, 0, 0) ts of
-        (False, _, _) -> fail $ "No window with key " ++ show wkey ++ "found. (focusWindowE)"
+        (False, _, _) -> fail $ "No window with key " ++ show k ++ "found. (focusWindowE)"
         (True, tabIndex, winIndex) -> do
             assign tabsA (fromJust $ PL.moveTo tabIndex ts)
             windowsA %= fromJust . PL.moveTo winIndex


### PR DESCRIPTION
The code tried to use Show instance for a function.
I don't know where it used to come from but it's not there
anymore. Build fails as:

  [ 53 of 145] Compiling Yi.Editor        ( src/library/Yi/Editor.hs, dist/build/Yi/Editor.o )

  src/library/Yi/Editor.hs:616:58-61:
    No instance for (Show (Window -> WindowRef))
      (maybe you haven't applied enough arguments to a function?)
      arising from a use of ‘show’
    In the first argument of ‘(++)’, namely ‘show wkey’
    In the second argument of ‘(++)’, namely
      ‘show wkey ++ "found. (focusWindowE)"’
    In the second argument of ‘($)’, namely
      ‘"No window with key " ++ show wkey ++ "found. (focusWindowE)"’

Revealed real bug.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>