### PR TITLE
Implement LayoutManager for the vty frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ cabal.sandbox.config
 .cabal-sandbox
 tags
 TAGS
+.stack-work/
+stack.yaml

--- a/src/library/Yi/Layout.hs
+++ b/src/library/Yi/Layout.hs
@@ -305,8 +305,8 @@ layoutToRectangles nb bounds (SingleWindow a) = [(a, bounds, nb)]
 layoutToRectangles nb bounds (Stack o ts) = handleStack o bounds ts'
     where ts' = if o == Vertical then setNbs nb ts
                 else case ts of
-                       []          -> []
                        (l, s) : xs -> (l, s, nb) : setNbs True xs
+                       []          -> []
           setNbs val = map (\(l, s) -> (l, s, val))
 layoutToRectangles nb bounds (Pair o p _ a b) = handleStack o bounds [(a,p,nb), (b,1-p,nb')]
     where nb' = if o == Horizontal then True else nb

--- a/src/library/Yi/Layout.hs
+++ b/src/library/Yi/Layout.hs
@@ -16,6 +16,7 @@ module Yi.Layout
     DividerRef,
     RelativeSize,
     dividerPositionA,
+    findDivider,
 
     -- * Layout managers
     -- ** The interface
@@ -122,6 +123,18 @@ dividerPositionA ref = lens getter (flip setter) where
   get' s@Stack{} = foldl' (<|>) Nothing (fmap (get' . fst) (wins s))
 
   invalidRef = error "Yi.Layout.dividerPositionA: invalid DividerRef"
+
+-- | Find the divider nearest to a given window, or just the first one
+-- in case the argument is 'Nothing'
+findDivider :: Eq a => Maybe a -> Layout a -> Maybe DividerRef
+findDivider mbw = go [] where
+  go path (SingleWindow w) = maybe Nothing (\w' ->
+                               if w == w' && not (null path)
+                               then Just (head path) else Nothing) mbw
+  go path (Pair _ _ ref l1 l2) = if null mbw then Just ref
+                                 else let p' = ref : path
+                                      in go p' l1 <|> go p' l2
+  go path (Stack _ ws) = foldr (<|>) Nothing $ map (go path . fst) ws
 
 instance Show a => Show (Layout a) where
   show (SingleWindow a) = show a

--- a/src/library/Yi/Layout.hs
+++ b/src/library/Yi/Layout.hs
@@ -55,7 +55,7 @@ import           Control.Lens               (Lens', lens)
 import qualified Control.Monad.State.Strict as Monad (State, evalState, get, put)
 import           Data.Default               (Default, def)
 import           Data.List                  (foldl', mapAccumL)
-import           Data.Maybe                 (fromMaybe)
+import           Data.Maybe                 (fromMaybe, isNothing)
 import           Data.Typeable              (Typeable, cast, typeOf)
 
 -------------------------------- Some design notes ----------------------
@@ -131,7 +131,7 @@ findDivider mbw = go [] where
   go path (SingleWindow w) = maybe Nothing (\w' ->
                                if w == w' && not (null path)
                                then Just (head path) else Nothing) mbw
-  go path (Pair _ _ ref l1 l2) = if null mbw then Just ref
+  go path (Pair _ _ ref l1 l2) = if isNothing mbw then Just ref
                                  else let p' = ref : path
                                       in go p' l1 <|> go p' l2
   go path (Stack _ ws) = foldr (<|>) Nothing $ map (go path . fst) ws

--- a/src/library/Yi/UI/SimpleLayout.hs
+++ b/src/library/Yi/UI/SimpleLayout.hs
@@ -15,13 +15,13 @@ module Yi.UI.SimpleLayout
 
 import           Prelude                        hiding (concatMap, mapM)
 
-import           Control.Lens                   (use, (.~), (&), (^.), to)
+import           Control.Lens                   (use, (.~), (&), (^.), to, _1)
 import           Control.Monad.State            (evalState, get, put)
 import           Data.Foldable                  (find, toList)
 import           Data.List                      (partition)
 import qualified Data.List.PointedList.Circular as PL (PointedList, focus)
 import qualified Data.Map.Strict                as M (Map, fromList)
-import           Data.Maybe                     (fromJust)
+import           Data.Maybe                     (fromMaybe)
 import           Data.Monoid                    ((<>))
 import qualified Data.Text                      as T (uncons)
 import           Data.Traversable               (mapM)
@@ -82,9 +82,10 @@ layout colCount rowCount e =
                     let r' = Rect 0 (rowCount - 1) colCount 1
                         w' = layoutWindow w e (sizeX r') (sizeY r')
                     in (w', r', False))
-      winRects = M.fromList . map (\(w, r, nb) -> (wkey w, (r, nb))) $ bigRects <> miniRects
-      updWs = map (\(w, _, _) -> w) $ bigRects <> miniRects
-      newWs = fmap (\w -> fromJust $ find ((== wkey w) . wkey) updWs) (windows e)
+      rects = bigRects <> miniRects
+      winRects = rects & M.fromList . map (\(w, r, nb) -> (wkey w, (r, nb)))
+      updWs = rects & map (^. _1)
+      newWs = windows e & fmap (\w -> fromMaybe w $ find ((== wkey w) . wkey) updWs)
 
 rectToRectangle :: Rect -> Rectangle
 rectToRectangle (Rect x y sx sy) = Rectangle (fromIntegral x)  (fromIntegral y)

--- a/src/library/Yi/UI/Vty.hs
+++ b/src/library/Yi/UI/Vty.hs
@@ -170,7 +170,7 @@ requestRefresh fs e = do
 refresh :: FrontendState -> Editor -> IO ()
 refresh fs e = do
     (colCount, rowCount) <- Vty.displayBounds (Vty.outputIface (fsVty fs))
-    let (_e, SL.Layout _tabbarRect winRects promptRect) = SL.layout colCount rowCount e
+    let (_e, SL.Layout tabbarRect winRects promptRect) = SL.layout colCount rowCount e
         ws = windows e
         (cmd, cmdSty) = statusLineInfo e
         niceCmd = arrangeItems cmd (SL.sizeX promptRect) (maxStatusHeight e)
@@ -191,7 +191,7 @@ refresh fs e = do
             ((appEndo <$> cmdSty) <*> baseAttributes)
                 (configStyle (configUI (fsConfig fs)))
         tabBarImage =
-            renderTabBar _tabbarRect (configStyle (configUI (fsConfig fs)))
+            renderTabBar tabbarRect (configStyle (configUI (fsConfig fs)))
                 (map (\(TabDescr t f) -> (t, f)) (toList (tabBarDescr e)))
         cmdImage = if null cmd
                    then Vty.emptyImage

--- a/src/library/Yi/UI/Vty.hs
+++ b/src/library/Yi/UI/Vty.hs
@@ -190,7 +190,7 @@ refresh fs e = do
             ((appEndo <$> cmdSty) <*> baseAttributes)
                 (configStyle (configUI (fsConfig fs)))
         tabBarImage =
-            renderTabBar (configStyle (configUI (fsConfig fs)))
+            renderTabBar _tabbarRect (configStyle (configUI (fsConfig fs)))
                 (map (\(TabDescr t f) -> (t, f)) (toList (tabBarDescr e)))
         cmdImage = if null cmd
                    then Vty.emptyImage
@@ -350,8 +350,8 @@ drawText wsty h w tabWidth bufData
         | otherwise = [(c, p)]
         where numeric = ord c
 
-renderTabBar :: UIStyle -> [(T.Text, Bool)] -> Vty.Image
-renderTabBar uiStyle = Vty.horizCat . fmap render
+renderTabBar :: SL.Rect -> UIStyle -> [(T.Text, Bool)] -> Vty.Image
+renderTabBar r uiStyle ts = (Vty.<|> padding) . Vty.horizCat $ fmap render ts
   where
     render (text, inFocus) = Vty.text' (tabAttr inFocus) (tabTitle text)
     tabTitle text   = ' ' `T.cons` text `T.snoc` ' '
@@ -361,3 +361,5 @@ renderTabBar uiStyle = Vty.horizCat . fmap render
     baseAttr False sty =
         attributesToAttr (appEndo (tabNotFocusedStyle uiStyle) sty) Vty.defAttr
             `Vty.withStyle` Vty.underline
+    padding = Vty.charFill (tabAttr False) ' ' (SL.sizeX r - width) 1
+    width = sum . map ((+2) . T.length . fst) $ ts


### PR DESCRIPTION
Currently the **vty** frontend ignores `LayoutManager` and uses a simple vertical stack layout implemented in [SimpleLayout.hs](https://github.com/yi-editor/yi/blob/master/src/library/Yi/UI/SimpleLayout.hs). In particular, you cannot change the divider position in order to, say, have a small console window at the bottom. `LayoutManager` is not as flexible as _XMonad_'s, but it is pretty nice and, as detailed in my comment on #148, can easily be extended with a `UserLayoutManager`.

After the patch the default layout looks like this (note that the main divider, corresponding to the `Pair` constructor, can be moved with `setDividerPosE`):
![screenshot](http://i.imgur.com/fog2D8u.jpg)

The basic layouting code was already there: the `layoutToRectangles` function from [Layout.hs](https://github.com/yi-editor/yi/blob/master/src/library/Yi/Layout.hs), which I extended to also deliver info about which windows have a neighbor to the left, needed by the vertical splitter code. Neither the _pango_ frontend nor any other part of the main repo used this function, so no other change was required.

I had to pad the tabbar because when having a horizontal split **vty** somehow automatically added padding by itself, repeating the last character from the tab line, but only for the extent of the leftward window.

In general, this is an in-place change of `SimpleLayout.hs` that should not affect anything else. The `layout` function there already had an `Editor` argument, within which the `LayoutManager` generated layout data can be found. I avoided extra refactoring to make reviewing easier. As mentioned, I want to also work on #148, but that requires a small change in API, and I'll wait until this patch gets dealt with.