### PR TITLE
System clipboard support with Hclip

### DIFF
--- a/src/library/Yi/Keymap/Cua.hs
+++ b/src/library/Yi/Keymap/Cua.hs
@@ -31,8 +31,7 @@ import           Yi.Keymap.Keys
 import           Yi.MiniBuffer            (commentRegion)
 import           Yi.Misc                  (adjBlock, selectAll)
 import           Yi.Rectangle             (getRectangle, killRectangle, yankRectangle)
-import qualified Yi.Rope                  as R (YiString, length, singleton, withText
-                                               , toString)
+import qualified Yi.Rope                  as R (YiString, length, singleton, withText)
 import           Yi.String                (lines', unlines')
 import           Yi.Keymap.Emacs.KillRing (clipboardToKillring, killringToClipboard)
 

--- a/src/library/Yi/Keymap/Emacs.hs
+++ b/src/library/Yi/Keymap/Emacs.hs
@@ -143,7 +143,7 @@ emacsKeys univArg =
          , ctrlCh 'h'           ?>> char 'b' ?>>! acceptedInputsOtherWindow
          , ctrlCh 'i'           ?>>! adjIndent IncreaseOnly
          , ctrlCh 'j'           ?>>! newlineAndIndentB
-         , ctrlCh 'k'           ?>>! killLineE univArg
+         , ctrlCh 'k'           ?>>! killLine univArg
          , ctrlCh 'l'           ?>>! (withCurrentBuffer scrollToCursorB >> userForceRefresh)
          , ctrlCh 'm'           ?>>! repeatingArg (insertB '\n')
          , ctrlCh 'n'           ?>>! repeatingArg (moveE VLine Forward)
@@ -155,7 +155,7 @@ emacsKeys univArg =
          , ctrlCh 't'           ?>>! repeatingArg swapB
          , ctrlCh 'v'           ?>>! scrollDownE univArg
          , ctrlCh 'w'           ?>>! killRegion
-         , ctrlCh 'y'           ?>>! yankE
+         , ctrlCh 'y'           ?>>! yank
          , ctrlCh 'z'           ?>>! suspendEditor
          , ctrlCh '+'           ?>>! repeatingArg (increaseFontSize 1)
          , ctrlCh '-'           ?>>! repeatingArg (decreaseFontSize 1)
@@ -204,7 +204,7 @@ emacsKeys univArg =
          , metaCh 'r'           ?>>! repeatingArg moveToMTB
          , metaCh 'u'           ?>>! repeatingArg uppercaseWordB
          , metaCh 't'           ?>>! repeatingArg (transposeB unitWord Forward)
-         , metaCh 'w'           ?>>! killRingSaveE
+         , metaCh 'w'           ?>>! killRingSave
          , metaCh 'x'           ?>>! executeExtendedCommandE
          , metaCh 'y'           ?>>! yankPopE
          , metaCh '.'           ?>>! promptTag

--- a/yi.cabal
+++ b/yi.cabal
@@ -296,7 +296,8 @@ library
     yi-language >= 0.1.1.0,
     oo-prototypes,
     yi-rope >= 0.7.0.0 && < 0.8,
-    exceptions
+    exceptions,
+    Hclip >= 3
 
   ghc-options: -Wall -fno-warn-orphans -ferror-spans
   ghc-prof-options: -prof -auto-all -rtsopts


### PR DESCRIPTION
Addresses #800.

For _Cua_ I updated inplace the `copy`/`paste` functions with the new behavior.

For _Emacs_ I kept the old `EditorM` functions and added new `YiM` functions that also sync the clipboard. I also updated the default bindings to the new ones. This way people can still use the old actions if they want.

For _Vim_ I added the 2 requested functions, but I'm not sure if `pasteFromClipboard` is right, as I'm not very familiar with the _Vim_ code base. I've just seen it done this way in `pasteRegisterBinding` from module [Yi.Keymap.Vim.InsertMap](https://github.com/yi-editor/yi/blob/master/src/library/Yi/Keymap/Vim/InsertMap.hs) but have not tested it yet.