### PR TITLE
Fixes some GHC warnings (see #808)

### DIFF
--- a/src/library/Yi/Core.hs
+++ b/src/library/Yi/Core.hs
@@ -57,7 +57,7 @@ import           Control.Lens                   (assign, mapped, use, uses,
                                                  (.~), (^.))
 import           Control.Monad                  (forever, void, when)
 import           Control.Monad.Base             (MonadBase (liftBase))
-import           Control.Monad.Error            ()
+import           Control.Monad.Except           ()
 import           Control.Monad.Reader           (MonadReader (ask), ReaderT (runReaderT), asks)
 import qualified Data.DelayList                 as DelayList (decrease, insert)
 import           Data.Foldable                  (Foldable (foldMap), elem, find, forM_, mapM_, or, toList)

--- a/src/library/Yi/Dired.hs
+++ b/src/library/Yi/Dired.hs
@@ -62,7 +62,7 @@ import qualified Data.Map                 as M (Map, assocs, delete, empty,
 import           Data.Maybe               (fromMaybe)
 import           Data.Monoid              (mempty, (<>))
 import qualified Data.Text                as T (Text, pack, unpack)
-import qualified Data.Text.ICU            as ICU (regex, find, unfold, group, MatchOption(..))
+import qualified Data.Text.ICU            as ICU (regex, find, group)
 import           Data.Time.Clock.POSIX    (posixSecondsToUTCTime)
 import           Data.Typeable            (Typeable)
 import           System.CanonicalizePath  (canonicalizePath)

--- a/src/library/Yi/Eval.hs
+++ b/src/library/Yi/Eval.hs
@@ -43,7 +43,7 @@ import Prelude hiding (mapM_)
 
 import Control.Applicative ( (<$>), (<*>) )
 import Control.Lens ( (^.), (<&>), (.=), (%=) )
-import Control.Monad (when)
+import Control.Monad (when, void, forever)
 import Data.Array ( elems )
 import Data.Binary ( Binary )
 import Data.Default ( Default, def )
@@ -55,8 +55,6 @@ import Data.Typeable ( Typeable )
 #ifdef HINT
 import Control.Concurrent
     ( takeMVar, putMVar, newEmptyMVar, MVar, forkIO )
-import Control.Monad
-    ( Monad((>>), (>>=), return), void, forever )
 import Control.Monad.Base ( MonadBase )
 import Control.Monad.Catch ( try )
 import Control.Monad.Trans ( lift )

--- a/src/library/Yi/Modes.hs
+++ b/src/library/Yi/Modes.hs
@@ -27,7 +27,7 @@ import           Data.List           (isPrefixOf)
 import           Data.Maybe          (fromMaybe, isJust)
 import           System.FilePath     (takeDirectory, takeExtension, takeFileName)
 import qualified Data.Text           as T (Text)
-import qualified Data.Text.ICU       as ICU (regex, find, MatchOption(..))
+import qualified Data.Text.ICU       as ICU (regex, find)
 
 import           Yi.Buffer
 import qualified Yi.IncrementalParse  as IncrParser (scanner)

--- a/src/library/Yi/Rectangle.hs
+++ b/src/library/Yi/Rectangle.hs
@@ -17,7 +17,7 @@ import           Control.Applicative ((<$>))
 import           Control.Monad       (forM_)
 import           Data.List           (sort, transpose)
 import           Data.Monoid         ((<>))
-import qualified Data.Text           as T (Text, concat, justifyLeft, length, pack, unpack)
+import qualified Data.Text           as T (Text, concat, justifyLeft, length)
 import qualified Data.Text.ICU       as ICU (regex, find, unfold, group)
 import           Yi.Buffer
 import           Yi.Editor           (EditorM, getRegE, setRegE, withCurrentBuffer)


### PR DESCRIPTION
- Removed unused imports
- used `Control.Monad.Except` instead of `Control.Monad.Error` in `Yi/Core.hs`

**I have not tested this with GHC-7.8.**