### PR TITLE
Rip out Control.Monad.Error.

### DIFF
--- a/src/library/Yi/Main.hs
+++ b/src/library/Yi/Main.hs
@@ -12,7 +12,7 @@ module Yi.Main (
                 Err(..),
                ) where
 
-import Control.Monad.Error
+import Control.Monad
 import Data.Char
 import Data.List (intercalate)
 import Data.Version (showVersion)
@@ -39,9 +39,6 @@ frontendNames = fmap fst' availableFrontends
         fst' (x,_) = x
 
 data Err = Err String ExitCode
-
-instance Error Err where
-    strMsg s = Err s (ExitFailure 1)
 
 -- | Configuration information which can be set in the command-line, but not
 -- in the user's configuration file.
@@ -125,8 +122,8 @@ getConfig shouldOpenInTabs (cfg, cfgcon) opt =
       Frontend f -> case lookup f availableFrontends of
                       Just frontEnd -> return (cfg { startFrontEnd = frontEnd }, cfgcon)
                       Nothing       -> fail "Panic: frontend not found"
-      Help          -> throwError $ Err usage ExitSuccess
-      Version       -> throwError $ Err versinfo ExitSuccess
+      Help          -> Left $ Err usage ExitSuccess
+      Version       -> Left $ Err versinfo ExitSuccess
       Debug         -> return (cfg { debugMode = True }, cfgcon)
       LineNo l      -> case startActions cfg of
                          x : xs -> return (cfg { startActions = x:makeAction (gotoLn (read l)):xs }, cfgcon)


### PR DESCRIPTION
This fixes deprecation errors that weren't fixed in the last
patch (because it wasn't obvious how to remove this).

I decided to try removing the Error instance to see what breaks
and then try to use it some other way. It turns out nothing breaks,
except possibly people's configurations but oh well, its deprecated.

This seems sane to me so I'll push it myself tomorrow assuming
Travis passes.

Fixes #808 