### PR TITLE
Support using a different Vty config

### DIFF
--- a/yi-frontend-vty/package.yaml
+++ b/yi-frontend-vty/package.yaml
@@ -11,6 +11,7 @@ ghc-options: -Wall -ferror-spans
 dependencies:
     - base >= 4.8 && < 5
     - containers
+    - data-default
     - dlist
     - microlens-platform
     - pointedlist

--- a/yi-frontend-vty/yi-frontend-vty.cabal
+++ b/yi-frontend-vty/yi-frontend-vty.cabal
@@ -24,6 +24,7 @@ library
   build-depends:
     base >= 4.8 && < 5,
     containers,
+    data-default,
     dlist,
     microlens-platform,
     pointedlist,


### PR DESCRIPTION
I'm not sure if anyone ever used this, but it seems like
a good idea not to regress if possible. I was already looking
at doing this anyway, since the current configuration (before
the package split) was silly and probably why it was removed
in the package split.

By using a YiConfigVariable instance we can implant the value
back in the configuration safely without having a reverse dependency.