### PR TITLE
Added temporary :copy command

### DIFF
--- a/yi-keymap-vim/package.yaml
+++ b/yi-keymap-vim/package.yaml
@@ -44,6 +44,7 @@ library:
         - Yi.Keymap.Vim.Ex.Commands.Buffers
         - Yi.Keymap.Vim.Ex.Commands.Cabal
         - Yi.Keymap.Vim.Ex.Commands.Common
+        - Yi.Keymap.Vim.Ex.Commands.Copy
         - Yi.Keymap.Vim.Ex.Commands.Delete
         - Yi.Keymap.Vim.Ex.Commands.Edit
         - Yi.Keymap.Vim.Ex.Commands.Global

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex.hs
@@ -38,6 +38,7 @@ import qualified Yi.Keymap.Vim.Ex.Commands.Tag          as Tag (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Undo         as Undo (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Write        as Write (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Yi           as Yi (parse)
+import qualified Yi.Keymap.Vim.Ex.Commands.Copy         as Copy (parse)
 import           Yi.Keymap.Vim.Ex.Eval                  (exEvalE, exEvalY)
 import           Yi.Keymap.Vim.Ex.Types                 (ExCommand (..), evStringToExCommand)
 
@@ -65,4 +66,5 @@ defExCommandParsers =
     , Undo.parse
     , Write.parse
     , Yi.parse
+    , Copy.parse
     ]

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Copy.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Copy.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module      :  Yi.Keymap.Vim.Ex.Commands.Copy
+-- License     :  GPL-2
+-- Maintainer  :  yi-devel@googlegroups.com
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- :copy ex command to copy selection to the clipboard.
+module Yi.Keymap.Vim.Ex.Commands.Copy (parse) where
+
+import           Control.Monad                    (void)
+import qualified Text.ParserCombinators.Parsec    as P (string)
+import           Yi.Editor                        (withCurrentBuffer)
+import           Yi.Keymap                        (Action (YiA))
+import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (parse, impureExCommand)
+import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow))
+import           Yi.Keymap.Vim.Common             (EventString)
+import           Yi.Types                         (YiM)
+import           Yi.Rope                          (toString, toText)
+import           Yi.Buffer.HighLevel              (getRawestSelectRegionB)
+import           Yi.Buffer.Region                 (readRegionB)
+import           Control.Monad.Base               (liftBase)
+import           System.Hclip                     (setClipboard)
+import           Yi.Core                          (errorEditor)
+import           Yi.Editor                        (printMsg, withEditor)
+import           Data.Monoid                      ((<>))
+
+parse :: EventString -> Maybe ExCommand
+parse = Common.parse $ do
+    void (P.string "'<,'>copy")
+    return $ Common.impureExCommand {
+        cmdShow = "copy"
+      , cmdAction = YiA copy
+      }
+
+copy :: YiM ()
+copy = do
+  selectionString <- withCurrentBuffer (readRegionB =<< getRawestSelectRegionB)
+  withEditor $ printMsg ("copied \"" <> toText selectionString <> "\"")
+  case toString selectionString of
+    "" -> errorEditor "Cannot copy empty selection"
+    s  -> liftBase (setClipboard s)

--- a/yi-keymap-vim/yi-keymap-vim.cabal
+++ b/yi-keymap-vim/yi-keymap-vim.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.14.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -54,6 +54,7 @@ library
       Yi.Keymap.Vim.Ex.Commands.Buffers
       Yi.Keymap.Vim.Ex.Commands.Cabal
       Yi.Keymap.Vim.Ex.Commands.Common
+      Yi.Keymap.Vim.Ex.Commands.Copy
       Yi.Keymap.Vim.Ex.Commands.Delete
       Yi.Keymap.Vim.Ex.Commands.Edit
       Yi.Keymap.Vim.Ex.Commands.Global


### PR DESCRIPTION
This can be used while #843 is sorted out.

Pasting from clipboard can be done with `:set paste` and `<C-v>` (or `<C-V>` in the vty).