### PR TITLE
Move from Parsec to Attoparsec.

### DIFF
--- a/yi-keymap-vim/package.yaml
+++ b/yi-keymap-vim/package.yaml
@@ -9,6 +9,7 @@ category: Yi
 ghc-options: -Wall -ferror-spans
 
 dependencies:
+    - attoparsec
     - base >= 4.8 && < 5
     - binary
     - containers
@@ -19,7 +20,6 @@ dependencies:
     - microlens-platform
     - mtl
     - oo-prototypes
-    - parsec
     - pointedlist
     - safe
     - semigroups

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/BufferDelete.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/BufferDelete.hs
@@ -13,7 +13,7 @@ module Yi.Keymap.Vim.Ex.Commands.BufferDelete (parse) where
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void)
 import           Data.Text                        ()
-import qualified Text.ParserCombinators.Parsec    as P (string, try)
+import qualified Data.Attoparsec.Text             as P (string, try)
 import           Yi.Editor                        (closeBufferAndWindowE)
 import           Yi.Keymap                        (Action (EditorA))
 import           Yi.Keymap.Vim.Common             (EventString)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Buffers.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Buffers.hs
@@ -14,9 +14,9 @@ module Yi.Keymap.Vim.Ex.Commands.Buffers (parse) where
 import           Control.Applicative              (Alternative ((<|>)))
 import           Lens.Micro.Platform                     (view)
 import           Control.Monad                    (void)
+import qualified Data.Attoparsec.Text             as P (string, try)
 import qualified Data.Map                         as M (elems, mapWithKey)
 import qualified Data.Text                        as T (intercalate, pack, unlines)
-import qualified Text.ParserCombinators.Parsec    as P (string, try)
 import           Yi.Buffer.Basic                  (BufferRef (BufferRef))
 import           Yi.Buffer.Misc                   (BufferId (MemBuffer), identA)
 import           Yi.Editor

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Cabal.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Cabal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -11,8 +12,8 @@ module Yi.Keymap.Vim.Ex.Commands.Cabal (parse) where
 
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void)
+import qualified Data.Attoparsec.Text             as P (string, try)
 import qualified Data.Text                        as T (pack)
-import qualified Text.ParserCombinators.Parsec    as P (string, try)
 import           Yi.Command                       (cabalBuildE)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Copy.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Copy.hs
@@ -12,7 +12,7 @@
 module Yi.Keymap.Vim.Ex.Commands.Copy (parse) where
 
 import           Control.Monad                    (void)
-import qualified Text.ParserCombinators.Parsec    as P (string)
+import qualified Data.Attoparsec.Text             as P (string)
 import           Yi.Editor                        (withCurrentBuffer)
 import           Yi.Keymap                        (Action (YiA))
 import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (parse, impureExCommand, parseRange)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Delete.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Delete.hs
@@ -13,7 +13,7 @@ module Yi.Keymap.Vim.Ex.Commands.Delete (parse) where
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void)
 import           Data.Text                        ()
-import qualified Text.ParserCombinators.Parsec    as P (string, try)
+import qualified Data.Attoparsec.Text             as P (string, try)
 import           Yi.Buffer.Adjusted               hiding (Delete)
 import           Yi.Keymap                        (Action (BufferA))
 import           Yi.Keymap.Vim.Common             (EventString)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Edit.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Edit.hs
@@ -16,7 +16,7 @@ import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void, when)
 import           Data.Maybe                       (isJust)
 import qualified Data.Text                        as T (Text, append, pack, unpack)
-import qualified Text.ParserCombinators.Parsec    as P (anyChar, many1, space, string, try, optionMaybe)
+import qualified Data.Attoparsec.Text             as P (anyChar, many1, space, string, try, option)
 import           Yi.Editor                        (MonadEditor (withEditor), newTabE)
 import           Yi.File                          (openNewFile)
 import           Yi.Keymap                        (Action (YiA))
@@ -26,7 +26,7 @@ import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdComp
 
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
-    tab <- P.optionMaybe (P.string "tab")
+    tab <- P.option Nothing $ Just <$> P.string "tab"
     void $ P.try (P.string "edit") <|> P.string "e"
     void $ P.many1 P.space
     filename <- T.pack <$> P.many1 P.anyChar

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Global.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Global.hs
@@ -15,7 +15,7 @@ import           Lens.Micro.Platform                           (use)
 import           Control.Monad                        (forM_, void, when)
 import           Data.Monoid                          ((<>))
 import qualified Data.Text                            as T (Text, isInfixOf, pack, snoc)
-import qualified Text.ParserCombinators.Parsec        as P (anyChar, char, many, noneOf, string, try)
+import qualified Data.Attoparsec.Text                 as P (anyChar, char, many', satisfy, string, try)
 import           Yi.Buffer.Adjusted
 import           Yi.Editor                            (withCurrentBuffer)
 import           Yi.Keymap                            (Action (BufferA, EditorA))
@@ -30,9 +30,9 @@ import           Yi.String                            (showT)
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     void $ P.try (P.string "global/") <|> P.string "g/"
-    predicate <- T.pack <$> P.many (P.noneOf "/")
+    predicate <- T.pack <$> P.many' (P.satisfy (/= '/'))
     void $ P.char '/'
-    cmdString <- Ev . T.pack <$> P.many P.anyChar
+    cmdString <- Ev . T.pack <$> P.many' P.anyChar
     cmd <- case evStringToExCommand allowedCmds cmdString of
             Just c -> return c
             _ -> fail "Unexpected command argument for global command."

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Help.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Help.hs
@@ -13,7 +13,7 @@ module Yi.Keymap.Vim.Ex.Commands.Help (parse) where
 
 import           Control.Monad                    (void)
 import qualified Data.Text                        as T (append, pack)
-import qualified Text.ParserCombinators.Parsec    as P (anyChar, many1, option, space, string, try)
+import qualified Data.Attoparsec.Text             as P (anyChar, many1, option, space, string, try)
 import           Yi.Command.Help                  (displayHelpFor)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Make.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Make.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -9,8 +10,7 @@
 
 module Yi.Keymap.Vim.Ex.Commands.Make (parse) where
 
-import qualified Data.Text                        as T (pack)
-import qualified Text.ParserCombinators.Parsec    as P (string)
+import qualified Data.Attoparsec.Text             as P (string)
 import           Yi.Command                       (makeBuildE)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)
@@ -22,6 +22,6 @@ parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     args <- P.string "make" *> Common.commandArgs
     return $ Common.impureExCommand {
-        cmdShow = T.pack "make"
+        cmdShow = "make"
       , cmdAction = YiA $ makeBuildE $ CommandArguments args
       }

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Quit.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Quit.hs
@@ -17,11 +17,11 @@ module Yi.Keymap.Vim.Ex.Commands.Quit (parse) where
 import           Control.Applicative              (Alternative ((<|>)))
 import           Lens.Micro.Platform              (use)
 import           Control.Monad                    (void, when)
+import qualified Data.Attoparsec.Text             as P (char, choice, many', string, try)
 import           Data.Foldable                    (find)
 import qualified Data.List.PointedList.Circular   as PL (length)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T (append)
-import qualified Text.ParserCombinators.Parsec    as P (char, choice, many, string, try)
 import           Yi.Buffer                        (bkey, file)
 import           Yi.Core                          (closeWindow, errorEditor, quitEditor)
 import           Yi.Editor
@@ -34,19 +34,21 @@ import           Yi.Monad                         (gets)
 import           Yi.String                        (showT)
 import           Yi.Window                        (bufkey)
 
+-- TODO wtf is the type of this function? It looks like it was introduced
+-- in the migration to microlens
 uses l f = f <$> use l
 
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ P.choice
     [ do
         void $ P.try ( P.string "xit") <|> P.string "x"
-        bangs <- P.many (P.char '!')
+        bangs <- P.many' (P.char '!')
         return (quit True (not $ null bangs) False)
     , do
-        ws <- P.many (P.char 'w')
+        ws <- P.many' (P.char 'w')
         void $ P.try ( P.string "quit") <|> P.string "q"
-        as <- P.many (P.try ( P.string "all") <|> P.string "a")
-        bangs <- P.many (P.char '!')
+        as <- P.many' (P.try ( P.string "all") <|> P.string "a")
+        bangs <- P.many' (P.char '!')
         return $! quit (not $ null ws) (not $ null bangs) (not $ null as)
     ]
 

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Read.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Read.hs
@@ -12,10 +12,10 @@ module Yi.Keymap.Vim.Ex.Commands.Read (parse) where
 
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad.Base               (liftBase)
+import qualified Data.Attoparsec.Text             as P (anyChar, many1, space, string, try)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T (Text, pack)
 import           System.Exit                      (ExitCode (..))
-import qualified Text.ParserCombinators.Parsec    as P (anyChar, many1, space, string, try)
 import           Yi.Buffer.HighLevel              (insertRopeWithStyleB)
 import           Yi.Buffer.Normal                 (RegionStyle (LineWise))
 import           Yi.Editor                        (printMsg, withCurrentBuffer)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Shell.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Shell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -11,7 +12,7 @@ module Yi.Keymap.Vim.Ex.Commands.Shell (parse) where
 
 import           Control.Monad                    (void)
 import qualified Data.Text                        as T (pack)
-import qualified Text.ParserCombinators.Parsec    as P (char, many1, noneOf)
+import qualified Data.Attoparsec.Text             as P (char, many1)
 import           Yi.Command                       (buildRun)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)
@@ -21,9 +22,9 @@ import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     void $ P.char '!'
-    cmd <- T.pack <$> P.many1 (P.noneOf " ")
+    cmd <- T.pack <$> P.many1 (P.char ' ')
     args <- Common.commandArgs
     return $ Common.impureExCommand {
-        cmdShow = T.pack "!"
+        cmdShow = "!"
       , cmdAction = YiA $ buildRun cmd args (const $ return ())
       }

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Sort.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Sort.hs
@@ -11,7 +11,7 @@
 module Yi.Keymap.Vim.Ex.Commands.Sort (parse) where
 
 import           Control.Monad                    (void)
-import qualified Text.ParserCombinators.Parsec    as P (string)
+import qualified Data.Attoparsec.Text             as P (string)
 import           Yi.Buffer
 import           Yi.Keymap                        (Action (BufferA))
 import           Yi.Keymap.Vim.Common             (EventString)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Tag.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Tag.hs
@@ -12,11 +12,11 @@ module Yi.Keymap.Vim.Ex.Commands.Tag (parse) where
 
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void)
+import qualified Data.Attoparsec.Text             as P (Parser, anyChar, endOfInput,
+                                                        many1, option,
+                                                        space, string)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T (pack)
-import qualified Text.ParserCombinators.Parsec    as P (GenParser, anyChar, eof,
-                                                        many1, optionMaybe,
-                                                        space, string)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)
 import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (impureExCommand, parse)
@@ -29,18 +29,18 @@ parse = Common.parse $ do
     void $ P.string "t"
     parseTag <|> parseNext
 
-parseTag :: P.GenParser Char () ExCommand
+parseTag :: P.Parser ExCommand
 parseTag = do
   void $ P.string "a"
-  void . P.optionMaybe $ P.string "g"
-  t <- P.optionMaybe $ do
+  void . P.option Nothing $ Just <$> P.string "g"
+  t <- P.option Nothing $ Just <$> do
       void $ P.many1 P.space
       P.many1 P.anyChar
   case t of
-    Nothing -> P.eof >> return (tag Nothing)
+    Nothing -> P.endOfInput >> return (tag Nothing)
     Just t' -> return $! tag (Just (Tag (T.pack t')))
 
-parseNext :: P.GenParser Char () ExCommand
+parseNext :: P.Parser ExCommand
 parseNext = do
   void $ P.string "next"
   return next

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Write.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Write.hs
@@ -12,9 +12,9 @@ module Yi.Keymap.Vim.Ex.Commands.Write (parse) where
 
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void, when)
+import qualified Data.Attoparsec.Text             as P (anyChar, many', many1, space, string, try)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T (Text, pack)
-import qualified Text.ParserCombinators.Parsec    as P (anyChar, many, many1, space, string, try)
 import           Yi.Buffer                        (BufferRef)
 import           Yi.Editor                        (printMsg)
 import           Yi.File                          (fwriteBufferE, viWrite, viWriteTo)
@@ -28,7 +28,7 @@ parse = Common.parse $
                (P.try (P.string "write") <|> P.string "w")
             *> (parseWriteAs <|> parseWrite)
     where parseWrite = do
-            alls <- P.many (P.try ( P.string "all") <|> P.string "a")
+            alls <- P.many' (P.try ( P.string "all") <|> P.string "a")
             return $! writeCmd $ not (null alls)
 
           parseWriteAs = do

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Yi.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Yi.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -11,8 +12,8 @@
 module Yi.Keymap.Vim.Ex.Commands.Yi (parse) where
 
 import           Control.Monad                    (void)
-import qualified Data.Text                        as T (pack)
-import qualified Text.ParserCombinators.Parsec    as P (anyChar, many1, space, string)
+import qualified Data.Attoparsec.Text             as P (many1, space, string, takeText)
+import qualified Data.Text                        as T (unpack)
 import           Yi.Eval                          (execEditorAction)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)
@@ -23,8 +24,8 @@ parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     void $ P.string "yi"
     void $ P.many1 P.space
-    cmd <- P.many1 P.anyChar
+    cmd <- P.takeText
     return $! Common.impureExCommand {
-        cmdAction = YiA $ execEditorAction cmd
-      , cmdShow = T.pack cmd
+        cmdAction = YiA $ execEditorAction (T.unpack cmd)
+      , cmdShow = cmd
       }

--- a/yi-keymap-vim/yi-keymap-vim.cabal
+++ b/yi-keymap-vim/yi-keymap-vim.cabal
@@ -23,6 +23,7 @@ library
   ghc-options: -Wall -ferror-spans
   build-depends:
       base >= 4.8 && < 5
+    , attoparsec
     , binary
     , containers
     , data-default
@@ -32,7 +33,6 @@ library
     , microlens-platform
     , mtl
     , oo-prototypes
-    , parsec
     , pointedlist
     , safe
     , semigroups


### PR DESCRIPTION
This gets us native text usage and automatic backtracking.

This was pretty much done in a semi-automatic manner, replacing
things like many with many', etc.

Fixes #846