### PR TITLE
Wire up pango (fixes #867)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
   apt:
     packages:
     - ghc-8.0.1
+    - libgconf2-dev
     sources: hvr-ghc
 
 before_install:
@@ -17,6 +18,7 @@ before_install:
  - export PATH=/opt/ghc/8.0.1/bin:$PATH
 
 install:
+ - stack install gtk2hs-buildtools
  - stack test -j2 --no-run-tests
 
 script:

--- a/lts.yaml
+++ b/lts.yaml
@@ -2,7 +2,8 @@ flags: {}
 packages:
 - yi-core
 - yi-frontend-vty
-# - yi-frontend-pango
+- yi-frontend-pango
+- yi-frontend-pango-gnome
 - yi-keymap-cua
 - yi-keymap-emacs
 - yi-keymap-vim
@@ -13,9 +14,8 @@ packages:
 - yi-language
 - yi
 extra-deps:
-- Hclip-3.0.0.3
 - ListLike-4.5
-# - gconf-0.13.1.0
-resolver: lts-6.9
+- gconf-0.13.0.3
+resolver: lts-6.10
 nix:
     shell-file: shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,8 @@ flags: {}
 packages:
 - yi-core
 - yi-frontend-vty
-# - yi-frontend-pango
+- yi-frontend-pango
+- yi-frontend-pango-gnome
 - yi-keymap-cua
 - yi-keymap-emacs
 - yi-keymap-vim
@@ -12,10 +13,8 @@ packages:
 - yi-ireader
 - yi-language
 - yi
+resolver: nightly-2016-07-31
 extra-deps:
-- Hclip-3.0.0.3
-- ListLike-4.5
-# - gconf-0.13.1.0
-resolver: nightly-2016-07-28
+  - gconf-0.13.1.0
 nix:
     shell-file: shell.nix

--- a/yi-frontend-pango-gnome/package.yaml
+++ b/yi-frontend-pango-gnome/package.yaml
@@ -1,0 +1,20 @@
+name: yi-frontend-pango-gnome
+version: 0.13.0
+synopsis: Gnome support for the Pango frontend of the Yi Editor
+maintainer: yi-devel@googlegroups.com
+license: GPL-2
+github: yi-editor/yi
+category: Yi
+
+ghc-options: -Wall
+
+dependencies:
+  - base >= 4.7 && < 5
+  - gtk
+  - gconf
+  - text
+
+library:
+  source-dirs: src
+  exposed-modules:
+    - Yi.Frontend.Pango.Gnome

--- a/yi-frontend-pango-gnome/src/Yi/Frontend/Pango/Gnome.hs
+++ b/yi-frontend-pango-gnome/src/Yi/Frontend/Pango/Gnome.hs
@@ -4,6 +4,7 @@ module Yi.Frontend.Pango.Gnome(watchSystemFont) where
 import Control.Monad
 import Graphics.UI.Gtk
 import System.Gnome.GConf
+import Data.Text
 
 monospaceFontKey :: String
 monospaceFontKey = "/desktop/gnome/interface/monospace_font_name"
@@ -14,7 +15,7 @@ watchSystemFont cb = do
   gconfAddDir gconf "/desktop/gnome/interface"
   watch gconf monospaceFontKey (cb <=< fontDescriptionFromString)
 
-watch :: GConfValueClass value => GConf -> String -> (value -> IO ()) -> IO ()
+watch :: GConf -> String -> (Text -> IO ()) -> IO ()
 watch gconf key cb = do
   cb =<< gconfGet gconf key
   gconfNotifyAdd gconf key $ \key' val -> when (key == key') (cb val)

--- a/yi-frontend-pango/package.yaml
+++ b/yi-frontend-pango/package.yaml
@@ -8,11 +8,14 @@ category: Yi
 
 ghc-options: -Wall -ferror-spans
 
+data-files:
+  - ../art/*.png
+  - ../art/*.pdf
+
 dependencies:
     - base >= 4.8 && < 5
     - containers
     - filepath
-    - gconf
     - glib  >= 0.13 && < 0.14
     - gtk >= 0.13 && < 0.15
     - microlens-platform

--- a/yi-frontend-pango/src/Yi/Frontend/Pango.hs
+++ b/yi-frontend-pango/src/Yi/Frontend/Pango.hs
@@ -57,9 +57,6 @@ import           Yi.Tab
 import           Yi.Types (fontsizeVariation, attributes)
 import qualified Yi.UI.Common as Common
 import           Yi.Frontend.Pango.Control (keyTable)
-#ifdef GNOME_ENABLED
-import           Yi.Frontend.Pango.Gnome(watchSystemFont)
-#endif
 import           Yi.Frontend.Pango.Layouts
 import           Yi.Frontend.Pango.Utils
 import           Yi.String (showT)
@@ -226,11 +223,7 @@ startNoMsgGtkHook userHook cfg ch outCh ed = do
   let actionCh = outCh . return
   tc <- newIORef =<< newCache ed actionCh
 
-#ifdef GNOME_ENABLED
-  let watchFont = watchSystemFont
-#else
   let watchFont = (fontDescriptionFromString ("Monospace 10" :: T.Text) >>=)
-#endif
   watchFont $ updateFont (configUI cfg) fontRef tc status
 
   -- I think this is the correct place to put it...

--- a/yi-frontend-pango/src/Yi/Frontend/Pango/Control.hs
+++ b/yi-frontend-pango/src/Yi/Frontend/Pango/Control.hs
@@ -11,24 +11,24 @@
 
 module Yi.Frontend.Pango.Control (
     Control(..)
-,   ControlM(..)
-,   Buffer(..)
-,   View(..)
-,   Iter(..)
-,   startControl
-,   runControl
-,   controlIO
-,   liftYi
-,   getControl
-,   newBuffer
-,   newView
-,   getBuffer
-,   setBufferMode
-,   withCurrentBuffer
-,   setText
-,   getText
-,   keyTable
-) where
+  , ControlM(..)
+  , Buffer(..)
+  , View(..)
+  , Iter(..)
+  , startControl
+  , runControl
+  , controlIO
+  , liftYi
+  , getControl
+  , newBuffer
+  , newView
+  , getBuffer
+  , setBufferMode
+  , withCurrentBuffer
+  , setText
+  , getText
+  , keyTable
+  ) where
 
 import Data.Text (unpack, pack, Text)
 import qualified Data.Text as T
@@ -197,8 +197,8 @@ startNoMsg :: ControlM () -> UIBoot
 startNoMsg main config input output ed = do
     control <- newEmptyMVar
     let wrappedMain = do
-        output [makeAction $ makeControl control]
-        void (runControl' main control)
+          output [makeAction $ makeControl control]
+          void (runControl' main control)
     return (mkUI wrappedMain control)
 
 end :: ControlM ()
@@ -798,9 +798,9 @@ handleMove view p0 event = do
   -- Relies on uiActionCh being synchronous
   selection <- liftBase $ newIORef ""
   let yiAction = do
-      txt <- withCurrentBuffer (readRegionB =<< getSelectRegionB)
+        txt <- withCurrentBuffer (readRegionB =<< getSelectRegionB)
              :: YiM R.YiString
-      liftBase $ writeIORef selection txt
+        liftBase $ writeIORef selection txt
   runAction $ makeAction yiAction
   txt <- liftBase $ readIORef selection
 

--- a/yi-frontend-pango/src/Yi/Frontend/Pango/Utils.hs
+++ b/yi-frontend-pango/src/Yi/Frontend/Pango/Utils.hs
@@ -6,7 +6,7 @@ module Yi.Frontend.Pango.Utils where
 import Control.Exception (catch, throw)
 
 import Data.Text (append)
-import Paths_yi
+import Paths_yi_frontend_pango
 import System.FilePath
 import Graphics.UI.Gtk
 import System.Glib.GError


### PR DESCRIPTION
It was a little more involved than just enabling pango in the stack.yaml:
- I removed the gconf dependency (and also the ability to watch for font changes in gnome or something like that), because gconf doesn't build with stack.
- I readded the art data-files to yi-frontend-pango.
- I fixed the indentation, because NondecreasingIndentation was removed in the split-packages branch (as it should be).
- (I also bumped the resolver version).