### PR TITLE
Use attoparsec instead of regexes

### DIFF
--- a/yi-core/package.yaml
+++ b/yi-core/package.yaml
@@ -33,6 +33,7 @@ flags:
 dependencies:
     - base >= 4.8
     - array
+    - attoparsec
     - binary >= 0.7
     - bytestring >= 0.9.1
     - containers

--- a/yi-core/test/Spec.hs
+++ b/yi-core/test/Spec.hs
@@ -2,6 +2,7 @@ import Test.Tasty
 
 import qualified Yi.CompletionTreeTests as CompletionTree (testSuite)
 import qualified Yi.TagTests            as Tag            (testSuite)
+import qualified Yi.Mode.CommonTests    as Mode.Common    (testSuite)
 
 main :: IO ()
 main = defaultMain tests
@@ -10,4 +11,5 @@ tests :: TestTree
 tests = testGroup "all" 
   [ CompletionTree.testSuite
   , Tag.testSuite
+  , Mode.Common.testSuite
   ]

--- a/yi-core/test/Yi/Mode/CommonTests.hs
+++ b/yi-core/test/Yi/Mode/CommonTests.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Yi.Mode.CommonTests (testSuite) where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.Tasty.HUnit
+
+import Yi.Mode.Common
+import Data.Attoparsec.Text (parseOnly)
+import Control.Applicative ((<|>))
+import Data.Either (isRight)
+
+testSuite :: TestTree
+testSuite = testGroup "Mode.Common" [unitTests]
+
+unitTests :: TestTree
+unitTests = testGroup "unit tests"
+  [ testGroup "shebangParser" $
+      [ testCase "matches a simple shebang" $
+          parseOnly (shebangParser "runhaskell") "#!/usr/bin/env runhaskell\n" @?= Right ()
+      , testCase "matches a complex shebang" $
+          map (parseOnly (shebangParser ("python" *> ("3" <|> "2" <|> "")))) ["#!/usr/bin/env python\n", "#!/usr/bin/env python2\n", "#!/usr/bin/env python3\n"] @?= [Right (), Right (), Right ()]
+      , testCase "ignores noise and spaces" $
+          parseOnly (shebangParser "runhaskell") "\n#!abcdefg\r\nABCdefG\n#!   /usr/bin/env  runhaskell    \r\n\n/AbcDe#!/fg\n" @?= Right ()
+      , testCase "parser fails correctly" $
+          isRight (parseOnly (shebangParser "runhaskell") "#!/usr/bin/env abc\n") @?= False
+      ]
+  ]

--- a/yi-mode-haskell/src/Yi/Mode/Haskell.hs
+++ b/yi-mode-haskell/src/Yi/Mode/Haskell.hs
@@ -55,7 +55,7 @@ import qualified Yi.Lexer.LiterateHaskell  as LiterateHaskell (HlState, alexScan
 import           Yi.MiniBuffer             (noHint, withMinibufferFree, withMinibufferGen)
 import qualified Yi.Mode.GHCi              as GHCi (ghciProcessArgs, ghciProcessName, spawnProcess)
 import qualified Yi.Mode.Interactive       as Interactive (queryReply)
-import           Yi.Mode.Common            (anyExtension, extensionOrContentsMatch)
+import           Yi.Mode.Common            (anyExtension, extensionOrContentsMatch, shebangParser)
 import           Yi.Monad                  (gets)
 import qualified Yi.Rope                   as R
 import           Yi.String                 (fillText, showT)
@@ -77,11 +77,10 @@ import           Yi.Utils                  (groupBy')
 -- Haskell hackers so it should be fine, at least for now.
 haskellAbstract :: Mode (tree TT)
 haskellAbstract = emptyMode
-  & modeAppliesA .~ extensionOrContentsMatch extensions shebangPattern
+  & modeAppliesA .~ extensionOrContentsMatch extensions (shebangParser "runhaskell")
   & modeNameA .~ "haskell"
   & modeToggleCommentSelectionA .~ Just (toggleCommentB "--")
   where extensions = ["hs", "x", "hsc", "hsinc"]
-        shebangPattern = "^#![[:space:]]*/usr/bin/env[[:space:]]+runhaskell"
 
 -- | "Clever" haskell mode, using the paren-matching syntax.
 cleverMode :: Mode (Paren.Tree (Tok Haskell.Token))


### PR DESCRIPTION
Fixes #839.

The only place where `text-icu` is used is now `Yi.Rectangle`, where it's used to align on a regex.