### PR TITLE
A bit renames

### DIFF
--- a/yi-core/src/Yi/Completion.hs
+++ b/yi-core/src/Yi/Completion.hs
@@ -17,7 +17,7 @@ module Yi.Completion
   , prefixMatch, infixUptoEndMatch
   , subsequenceMatch
   , containsMatch', containsMatch, containsMatchCaseInsensitive
-  , mkIsPrefixOf
+  , isCasePrefixOf
   )
 where
 
@@ -36,12 +36,12 @@ import           Yi.Utils            (commonPrefix)
 
 -- | Like usual 'T.isPrefixOf' but user can specify case sensitivity.
 -- See 'T.toCaseFold' for exotic unicode gotchas.
-mkIsPrefixOf :: Bool -- ^ Is case-sensitive?
+isCasePrefixOf :: Bool -- ^ Is case-sensitive?
              -> T.Text
              -> T.Text
              -> Bool
-mkIsPrefixOf True = T.isPrefixOf
-mkIsPrefixOf False = T.isPrefixOf `on` T.toCaseFold
+isCasePrefixOf True = T.isPrefixOf
+isCasePrefixOf False = T.isPrefixOf `on` T.toCaseFold
 
 -- | Prefix matching function, for use with 'completeInList'
 prefixMatch :: T.Text -> T.Text -> Maybe T.Text
@@ -67,7 +67,7 @@ containsMatch' :: Bool -> T.Text -> T.Text -> Maybe T.Text
 containsMatch' caseSensitive pattern str =
   const str <$> find (pattern `tstPrefix`) (T.tails str)
   where
-    tstPrefix = mkIsPrefixOf caseSensitive
+    tstPrefix = isCasePrefixOf caseSensitive
 
 containsMatch :: T.Text -> T.Text -> Maybe T.Text
 containsMatch = containsMatch' True

--- a/yi-core/src/Yi/Completion.hs
+++ b/yi-core/src/Yi/Completion.hs
@@ -14,7 +14,7 @@ module Yi.Completion
   ( completeInList, completeInList'
   , completeInListCustomShow
   , commonPrefix
-  , prefixMatch, infixMatch
+  , prefixMatch, infixUptoEndMatch
   , subsequenceMatch
   , containsMatch', containsMatch, containsMatchCaseInsensitive
   , mkIsPrefixOf
@@ -47,9 +47,9 @@ mkIsPrefixOf False = T.isPrefixOf `on` T.toCaseFold
 prefixMatch :: T.Text -> T.Text -> Maybe T.Text
 prefixMatch prefix s = if prefix `T.isPrefixOf` s then Just s else Nothing
 
--- | Infix matching function, for use with 'completeInList'
-infixMatch :: T.Text -> T.Text -> Maybe T.Text
-infixMatch needle haystack = case T.breakOn needle haystack of
+-- | Text from the match up to the end, for use with 'completeInList'
+infixUptoEndMatch :: T.Text -> T.Text -> Maybe T.Text
+infixUptoEndMatch needle haystack = case T.breakOn needle haystack of
   (_, t) -> if T.null t then Nothing else Just t
 
 -- | A simple fuzzy match algorithm. Example: "abc" matches "a1b2c"

--- a/yi-core/src/Yi/Completion.hs
+++ b/yi-core/src/Yi/Completion.hs
@@ -52,7 +52,7 @@ infixMatch :: T.Text -> T.Text -> Maybe T.Text
 infixMatch needle haystack = case T.breakOn needle haystack of
   (_, t) -> if T.null t then Nothing else Just t
 
--- | Example: "abc" matches "a1b2c"
+-- | A simple fuzzy match algorithm. Example: "abc" matches "a1b2c"
 subsequenceMatch :: String -> String -> Bool
 subsequenceMatch needle haystack = go needle haystack
   where go (n:ns) (h:hs) | n == h = go ns hs

--- a/yi-core/src/Yi/MiniBuffer.hs
+++ b/yi-core/src/Yi/MiniBuffer.hs
@@ -275,7 +275,7 @@ withMinibufferFin prompt possibilities act
     -- may have for example two possibilities which share a long
     -- prefix and hence we wish to press tab to complete up to the
     -- point at which they differ.
-    completer s = return $ fromMaybe s $ commonTPrefix $ catMaybes (infixMatch s <$> possibilities)
+    completer s = return $ fromMaybe s $ commonTPrefix $ catMaybes (infixUptoEndMatch s <$> possibilities)
 
 -- | TODO: decide whether we should be keeping 'T.Text' here or moving
 -- to 'YiString'.

--- a/yi-core/src/Yi/TextCompletion.hs
+++ b/yi-core/src/Yi/TextCompletion.hs
@@ -36,7 +36,7 @@ import qualified Data.Text           as T (Text, drop, groupBy, head, isPrefixOf
 import qualified Data.Text.Encoding  as E (decodeUtf8, encodeUtf8)
 import           Data.Typeable       (Typeable)
 import           Yi.Buffer
-import           Yi.Completion       (completeInList, mkIsPrefixOf)
+import           Yi.Completion       (completeInList, isCasePrefixOf)
 import           Yi.Editor
 import           Yi.Keymap           (YiM)
 import qualified Yi.Rope             as R (fromText, toText)
@@ -103,7 +103,7 @@ wordCompleteString' caseSensitive =
                    textRegion =<< regionOfPartB unitWord Backward)
                  (\_ -> withEditor wordsForCompletion)
                  (\_ -> return ())
-                 (mkIsPrefixOf caseSensitive)
+                 (isCasePrefixOf caseSensitive)
   where
     textRegion = fmap R.toText . readRegionB
 


### PR DESCRIPTION
Improved comment *(to be able to find the function with grep)*, renamed two functions to mirror their actual functionality.

I was actually trying to make an analog of ido-switch-buffer, but wasn't successful, but, at least, noticed some function names that tells little about their purpose.