### PR TITLE
Emacs config port

### DIFF
--- a/example-configs/yi-emacs-vty-dynamic/yi-config.cabal
+++ b/example-configs/yi-emacs-vty-dynamic/yi-config.cabal
@@ -15,5 +15,7 @@ executable yi
                      , yi-mode-haskell
                      , yi-mode-javascript
                      , yi-misc-modes
+                     , yi-rope
+                     , microlens-platform
   default-language:    Haskell2010
   ghc-options:         -O2 -threaded

--- a/yi-keymap-emacs/src/Yi/Keymap/Emacs.hs
+++ b/yi-keymap-emacs/src/Yi/Keymap/Emacs.hs
@@ -19,7 +19,7 @@
 -- native names.
 
 module Yi.Keymap.Emacs ( keymap
-                       , mkKeymap
+                       , mkKeymapSet
                        , defKeymap
                        , ModeMap(..)
                        , eKeymap
@@ -27,13 +27,13 @@ module Yi.Keymap.Emacs ( keymap
                        ) where
 
 import Control.Applicative      (Alternative ((<|>), empty, some))
-import Lens.Micro.Platform      ((.=), makeLenses, (%=))
 import Control.Monad            (replicateM_, unless, void)
 import Control.Monad.State      (gets)
 import Data.Char                (digitToInt, isDigit)
 import Data.Maybe               (fromMaybe)
 import Data.Prototype           (Proto (Proto), extractValue)
 import Data.Text                ()
+import Lens.Micro.Platform      ((.=), makeLenses, (%=))
 import Yi.Buffer
 import Yi.Command               (shellCommandE)
 import Yi.Core
@@ -58,10 +58,10 @@ data ModeMap = ModeMap { _eKeymap :: Keymap
 $(makeLenses ''ModeMap)
 
 keymap :: KeymapSet
-keymap = mkKeymap defKeymap
+keymap = mkKeymapSet defKeymap
 
-mkKeymap :: Proto ModeMap -> KeymapSet
-mkKeymap = modelessKeymapSet . _eKeymap . extractValue
+mkKeymapSet :: Proto ModeMap -> KeymapSet
+mkKeymapSet = modelessKeymapSet . _eKeymap . extractValue
 
 defKeymap :: Proto ModeMap
 defKeymap = Proto template


### PR DESCRIPTION
Port of [the old Emacs config](https://github.com/yi-editor/yi/blob/8f99ba6e6dc49ff71f50607ace54d186de7f7be8/example-configs/yi-simple.hs).

There's also rename `mkKeymap` → `mkKeymapSet` because it is how the same function named in Vim configs *(for consistency)*.