### PR TITLE
Upgrade to use optparse-applicative-0.13

### DIFF
--- a/example-configs/yi-all-static/Main.hs
+++ b/example-configs/yi-all-static/Main.hs
@@ -16,6 +16,7 @@ import Control.Monad.State.Lazy (execStateT)
 import Data.List                (intersperse)
 import Lens.Micro.Platform      ((.=))
 import Data.Maybe               (fromMaybe)
+import Data.Monoid              ((<>))
 
 import Options.Applicative
 
@@ -70,10 +71,10 @@ data CommandLineOptions = CommandLineOptions {
   }
 
 commandLineOptions :: Parser (Maybe CommandLineOptions)
-commandLineOptions = flag' Nothing 
-                       ( long "version" 
-                      <> short 'v' 
-                      <> help "Show the version number") 
+commandLineOptions = flag' Nothing
+                       ( long "version"
+                      <> short 'v'
+                      <> help "Show the version number")
   <|> (Just <$> (CommandLineOptions
     <$> optional (strOption
         ( long "frontend"
@@ -96,7 +97,7 @@ commandLineOptions = flag' Nothing
 main :: IO ()
 main = do
     mayClo <- execParser opts
-    case mayClo of 
+    case mayClo of
       Nothing -> putStrLn "Yi 0.13.0.1"
       Just clo -> do
         let openFileActions = intersperse (EditorA newTabE) (map (YiA . openNewFile) (files clo))
@@ -105,7 +106,7 @@ main = do
             (runConfigM (myConfig (frontend clo) (keymap clo) >> (startActionsA .= (openFileActions ++ [moveLineAction]))))
             defaultConfig
         startEditor cfg Nothing
-  where 
+  where
    opts = info (helper <*> commandLineOptions)
      ( fullDesc
     <> progDesc "Edit files"

--- a/example-configs/yi-all-static/package.yaml
+++ b/example-configs/yi-all-static/package.yaml
@@ -29,7 +29,7 @@ dependencies:
     - base >= 4.8 && < 5
     - microlens-platform
     - mtl
-    - optparse-applicative
+    - optparse-applicative >= 0.13.0.0
     - yi-core
     - yi-misc-modes
     - yi-mode-haskell

--- a/yi/Main.hs
+++ b/yi/Main.hs
@@ -4,6 +4,7 @@ import Control.Monad.State.Lazy (execStateT)
 import Data.List                (intersperse)
 import Lens.Micro.Platform      ((.=))
 import Data.Maybe               (fromMaybe)
+import Data.Monoid              ((<>))
 
 import Options.Applicative
 
@@ -58,10 +59,10 @@ data CommandLineOptions = CommandLineOptions {
   }
 
 commandLineOptions :: Parser (Maybe CommandLineOptions)
-commandLineOptions = flag' Nothing 
-                       ( long "version" 
-                      <> short 'v' 
-                      <> help "Show the version number") 
+commandLineOptions = flag' Nothing
+                       ( long "version"
+                      <> short 'v'
+                      <> help "Show the version number")
   <|> (Just <$> (CommandLineOptions
     <$> optional (strOption
         ( long "frontend"
@@ -84,7 +85,7 @@ commandLineOptions = flag' Nothing
 main :: IO ()
 main = do
     mayClo <- execParser opts
-    case mayClo of 
+    case mayClo of
       Nothing -> putStrLn "Yi 0.13.0.1"
       Just clo -> do
         let openFileActions = intersperse (EditorA newTabE) (map (YiA . openNewFile) (files clo))
@@ -93,7 +94,7 @@ main = do
             (runConfigM (myConfig (frontend clo) (keymap clo) >> (startActionsA .= (openFileActions ++ [moveLineAction]))))
             defaultConfig
         startEditor cfg Nothing
-  where 
+  where
    opts = info (helper <*> commandLineOptions)
      ( fullDesc
     <> progDesc "Edit files"

--- a/yi/package.yaml
+++ b/yi/package.yaml
@@ -30,7 +30,7 @@ dependencies:
     - base >= 4.8 && < 5
     - microlens-platform >= 0.3.4.0
     - mtl >= 2.2.1
-    - optparse-applicative >= 0.12.1.0
+    - optparse-applicative >= 0.13.0.0
     - yi-core >= 0.13.0.1
     - yi-misc-modes >= 0.13.0.1
     - yi-mode-haskell >= 0.13.0.1


### PR DESCRIPTION
`optparse-applicative-0.13` stops defining its own `(<>)` operator and instead relies on the programmer to use `Data.Monoid.<>`. I don't see a good way of making this backwards compatible without requiring lots of ugly CPP, so I opted to simply require `optparse-applicative-0.13` or later in order to fix this issue.

Fixes #921.