### PR TITLE
Fix document about BufferImpl is hidden

### DIFF
--- a/yi-core/src/Yi/Buffer/Implementation.hs
+++ b/yi-core/src/Yi/Buffer/Implementation.hs
@@ -62,6 +62,7 @@ module Yi.Buffer.Implementation
   , markPointAA
   , markGravityAA
   , mem
+  , BufferImpl
   ) where
 
 import           GHC.Generics        (Generic)


### PR DESCRIPTION
BufferImpl is hidden in Yi.Buffer.Implementation,  
but BufferImpl is shown somewhere.

for example) [undoU](https://www.stackage.org/haddock/lts-7.7/yi-0.12.6/Yi-Buffer-Undo.html#v:undoU)
