### PR TITLE
Expose default Cua config

### DIFF
--- a/yi-keymap-cua/package.yaml
+++ b/yi-keymap-cua/package.yaml
@@ -19,4 +19,5 @@ dependencies:
 library:
     source-dirs: src
     exposed-modules:
+        - Yi.Config.Default.Cua
         - Yi.Keymap.Cua


### PR DESCRIPTION
It seems like it was omitted accidentally since all others are exposed (e.g. configureVty, configureVim...)