### PR TITLE
Completion bugfix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
 with pkgs;
+let ghc = haskell.packages.ghc801.ghcWithPackages (pkgs: [pkgs.gtk2hs-buildtools]);
+in
 
 stdenv.mkDerivation {
   name = "yi";
@@ -9,16 +11,20 @@ stdenv.mkDerivation {
       cairo
       pango
       gtk
-      haskell.compiler.ghc7103
+      ghc
       haskellPackages.gtk2hs-buildtools
       icu.out
       ncurses.out
       pkgconfig
       glibcLocales
+      zlib.out
   ];
 
   shellHook = ''
     export LC_ALL=en_US.UTF-8
+    export PATH="${haskellPackages.gtk2hs-buildtools}/bin:$PATH"
+    export CPATH="${icu.dev}/include:${ncurses.dev}/include:$CPATH"
+    export LIBRARY_PATH="${icu.dev}/lib:${ncurses.dev}/lib:${zlib.out}/lib:$LIBRARY_PATH"
     export LD_LIBRARY_PATH="${icu.out}/lib:${ncurses.out}/lib:$LD_LIBRARY_PATH"
   '';
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,4 +20,5 @@ extra-deps:
 - Hclip-3.0.0.4
 - optparse-applicative-0.13.0.0
 - vty-5.13
+- ListLike-4.5
 resolver: nightly-2016-10-21

--- a/yi-core/package.yaml
+++ b/yi-core/package.yaml
@@ -181,6 +181,7 @@ tests:
       - tasty
       - tasty-hunit
       - tasty-quickcheck
+      - quickcheck-text
       - yi-core
       - text
       - containers

--- a/yi-core/src/Yi/Completion.hs
+++ b/yi-core/src/Yi/Completion.hs
@@ -49,6 +49,7 @@ prefixMatch prefix s = if prefix `T.isPrefixOf` s then Just s else Nothing
 
 -- | Text from the match up to the end, for use with 'completeInList'
 infixUptoEndMatch :: T.Text -> T.Text -> Maybe T.Text
+infixUptoEndMatch "" haystack = Just haystack
 infixUptoEndMatch needle haystack = case T.breakOn needle haystack of
   (_, t) -> if T.null t then Nothing else Just t
 

--- a/yi-core/test/Spec.hs
+++ b/yi-core/test/Spec.hs
@@ -1,6 +1,7 @@
 import Test.Tasty
 
 import qualified Yi.CompletionTreeTests as CompletionTree (testSuite)
+import qualified Yi.CompletionTests     as Completion (testSuite)
 import qualified Yi.TagTests            as Tag            (testSuite)
 import qualified Yi.Mode.CommonTests    as Mode.Common    (testSuite)
 
@@ -9,7 +10,8 @@ main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "all" 
-  [ CompletionTree.testSuite
+  [ Completion.testSuite
+  , CompletionTree.testSuite
   , Tag.testSuite
   , Mode.Common.testSuite
   ]

--- a/yi-core/test/Yi/CompletionTests.hs
+++ b/yi-core/test/Yi/CompletionTests.hs
@@ -1,0 +1,28 @@
+module Yi.CompletionTests (testSuite) where
+
+import Data.List (sort,nub)
+import Data.Maybe(isJust)
+import Data.Monoid
+import Data.Text.Arbitrary()
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Yi.Completion as C
+import qualified Data.Map as M
+import qualified Data.Text as T
+
+testSuite :: TestTree
+testSuite = testGroup "Completion" [propertyTests]
+
+propertyTests :: TestTree
+propertyTests = testGroup "properties"
+  [ testProperty "infixUptoEndMatch needle (pre <> needle <> post) == Just (needle <> post) if needle and post not empty and needle not in pre" $
+      \pre needle post ->
+           not (needle `T.isInfixOf` pre) ==>
+           not (T.null post) ==>
+             infixUptoEndMatch needle (pre <> needle <> post) == Just (needle <> post)
+  , testProperty "infixUptoEndMatch \"\" x == Just x" $
+      \x -> infixUptoEndMatch T.empty x == Just x
+  , testProperty "isJust (infixUptoEndMatch needle haystack) == needle `Data.Text.isInfixOf` haystack" $
+      \needle haystack ->
+            isJust (infixUptoEndMatch needle haystack) == needle `T.isInfixOf` haystack
+  ]


### PR DESCRIPTION
Hello Yi maintainers,

I've found a little bug where an error would occur if you have not typed anything before hitting autocomplete, for example when switching buffers. The error was caused by the partial function Data.Text.breakOn (breakOn "" x  -->  Exception: Data.Text.breakOn: empty input)

This pull request includes:
 - the fix
 - extra quickcheck properties
 - some changes to make yi build
    - an improved shell.nix
    - an extra-deps line in stack.yaml to make instance ListLike Text Char work (weird but apparently necessary)
