### PR TITLE
Fix the Windows build

### DIFF
--- a/yi-core/src/Yi/Process.hs
+++ b/yi-core/src/Yi/Process.hs
@@ -17,8 +17,10 @@ import           System.Process.ListLike (ListLikeProcessIO, readProcessWithExit
 import           Yi.Buffer.Basic         (BufferRef)
 import           Yi.Monad                (repeatUntilM)
 
-#ifndef mingw32_HOST_OS
-import System.Posix.IO (createPipe, fdToHandle)
+#ifdef mingw32_HOST_OS
+import           System.Process          (runInteractiveProcess)
+#else
+import           System.Posix.IO         (createPipe, fdToHandle)
 #endif
 
 runProgCommand :: ListLikeProcessIO a c => String -> [String] -> IO (ExitCode, a, a)


### PR DESCRIPTION
Currently, `yi-core` fails to install on Windows with this error:

```
$ cabal install yi-core
Resolving dependencies...
Configuring yi-core-0.13.5...
Building yi-core-0.13.5...
Failed to install yi-core-0.13.5
Build log ( C:\Users\RyanGlScott\AppData\Roaming\cabal\logs\yi-core-0.13.5.log ):
Building yi-core-0.13.5...
Preprocessing library yi-core-0.13.5...
<build output elided>
[28 of 74] Compiling Yi.Process       ( src\Yi\Process.hs, dist\build\Yi\Process.o )

src\Yi\Process.hs:76:29-49: error:
    * Variable not in scope:
        runInteractiveProcess
          :: FilePath
             -> [String]
             -> Maybe a1
             -> Maybe a0
             -> IO (Handle, Handle, Handle, ProcessHandle)
    * Perhaps you want to add `runInteractiveProcess'
      to the import list in the import of `System.Process'
      (src\Yi\Process.hs:15:1-68).
cabal: Leaving directory 'C:\msys64\tmp\cabal-tmp-4840\yi-core-0.13.5'
cabal.exe: Error: some packages failed to install:
yi-core-0.13.5 failed during the building phase. The exception was:
ExitFailure 1
```

This PR fixes the issue.