### PR TITLE
Support all abbreviations for :nohlsearch

### DIFF
--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Nohl.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Nohl.hs
@@ -10,17 +10,17 @@
 
 module Yi.Keymap.Vim.Ex.Commands.Nohl (parse) where
 
-import           Data.Text                        ()
+import qualified Data.Text                        as T
 import           Yi.Keymap                        (Action (EditorA))
-import           Yi.Keymap.Vim.Common             (EventString)
+import           Yi.Keymap.Vim.Common             (EventString(..))
 import           Yi.Keymap.Vim.Ex.Commands.Common (pureExCommand)
 import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow))
 import           Yi.Search                        (resetRegexE)
 
 parse :: EventString -> Maybe ExCommand
-parse s = if s == "nohl" || s == "nohlsearch"
-    then Just nohl
-    else Nothing
+parse (Ev s)
+  | T.isPrefixOf s "nohlsearch" && T.compareLength s 2 == GT = Just nohl
+  | otherwise                                                = Nothing
 
 nohl :: ExCommand
 nohl = pureExCommand {

--- a/yi-keymap-vim/tests/Vim/TestExCommandParsers.hs
+++ b/yi-keymap-vim/tests/Vim/TestExCommandParsers.hs
@@ -2,6 +2,7 @@
 module Vim.TestExCommandParsers (tests) where
 
 import           Control.Applicative
+import           Data.List (inits)
 import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Text as T
@@ -14,6 +15,7 @@ import qualified Yi.Keymap.Vim.Ex.Commands.Buffer as Buffer
 import qualified Yi.Keymap.Vim.Ex.Commands.BufferDelete as BufferDelete
 import qualified Yi.Keymap.Vim.Ex.Commands.Delete as Delete
 import qualified Yi.Keymap.Vim.Ex.Commands.Registers as Registers
+import qualified Yi.Keymap.Vim.Ex.Commands.Nohl as Nohl
 
 data CommandParser = CommandParser
     { cpDescription  :: String
@@ -110,6 +112,14 @@ commandParsers =
           , "register"
           , "registers"
           ]
+          False
+          False
+          (pure "")
+
+    , CommandParser
+          "Nohl.parse"
+          (Nohl.parse . Ev . T.pack)
+          (drop 3 $ inits "nohlsearch")
           False
           False
           (pure "")


### PR DESCRIPTION
Vim accepts all prefixes of `:nohlsearch` that are longer than `:noh`.