### PR TITLE
Fix behaviour of f,t,F,T when given a count

### DIFF
--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Motion.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Motion.hs
@@ -205,21 +205,20 @@ matchGotoCharMove :: String -> MatchResult Move
 matchGotoCharMove (m:[]) | m `elem` ('f' : "FtT") = PartialMatch
 matchGotoCharMove (m:"<lt>") | m `elem` ('f' : "FtT") = matchGotoCharMove (m:"<")
 matchGotoCharMove (m:c:[]) | m `elem` ('f' : "FtT") = WholeMatch $ Move style False action
-    where (dir, style, move) =
+    where (dir, style, move, offset) =
               case m of
-                  'f' -> (Forward, Inclusive, nextCInLineInc c)
-                  't' -> (Forward, Inclusive, nextCInLineExc c)
-                  'F' -> (Backward, Exclusive, prevCInLineInc c)
-                  'T' -> (Backward, Exclusive, prevCInLineExc c)
+                  'f' -> (Forward, Inclusive, nextCInLineInc c, pure ())
+                  't' -> (Forward, Inclusive, nextCInLineInc c, moveB Character Backward)
+                  'F' -> (Backward, Exclusive, prevCInLineInc c, pure ())
+                  'T' -> (Backward, Exclusive, prevCInLineInc c, moveB Character Forward)
                   _ -> error "can't happen"
           action mcount = do
                   let count = fromMaybe 1 mcount
                   p0 <- pointB
-                  replicateM_ (count - 1) $ do
-                      move
-                      moveB Character dir
+                  replicateM_ (count - 1) $ move
                   p1 <- pointB
                   move
                   p2 <- pointB
+                  offset
                   when (p1 == p2) $ moveTo p0
 matchGotoCharMove _ = NoMatch

--- a/yi-keymap-vim/tests/vimtests/find/f6.test
+++ b/yi-keymap-vim/tests/vimtests/find/f6.test
@@ -1,0 +1,12 @@
+-- Input
+(1,1)
+Foo ii Bar
+abc def ghi
+qwe rty uiop
+-- Output
+(1,6)
+Foo ii Bar
+abc def ghi
+qwe rty uiop
+-- Events
+2fi

--- a/yi-keymap-vim/tests/vimtests/find/t7.test
+++ b/yi-keymap-vim/tests/vimtests/find/t7.test
@@ -1,0 +1,12 @@
+-- Input
+(1,1)
+Foo ii bar
+abc def ghi
+qwe rty uiop
+-- Output
+(1,5)
+Foo ii bar
+abc def ghi
+qwe rty uiop
+-- Events
+2ti


### PR DESCRIPTION
The problem is that we can't just repeat the `t` and `T` movements n times, because they are idempotent. Instead we really want to do the f or F movement n times and then go back one character. The old buggy solution just skip over one character the first n-1 times instead. This however creates problems if the search targets are right next to each other (see added tests). For example `2fc` skips over three adjacent `c`s and `2tc` will not move at all on two adjacent `c`s because the last move was stationary.