### PR TITLE
:substitute optional trailing delimiter

### DIFF
--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Substitute.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Substitute.hs
@@ -11,10 +11,11 @@
 
 module Yi.Keymap.Vim.Ex.Commands.Substitute (parse) where
 
-import           Control.Applicative              (Alternative ((<|>)))
+import           Control.Applicative              (Alternative)
 import           Control.Monad                    (void)
 import qualified Data.Attoparsec.Text             as P (char, inClass, many', match,
-                                                        satisfy, string, try)
+                                                        satisfy, string, option,
+                                                        (<?>), Parser)
 import           Data.Maybe                       (fromMaybe)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T (Text, cons, snoc)
@@ -31,10 +32,17 @@ import           Yi.Regex                         (makeSearchOptsM)
 import qualified Yi.Rope                          as R (YiString, fromString, length, null, toText, toString)
 import           Yi.Search
 
+-- | Skip one or no occurrences of a given parser.
+skipOptional :: Alternative f => f a -> f ()
+skipOptional p = P.option () (() <$ p)
+{-# SPECIALIZE skipOptional :: P.Parser a -> P.Parser () #-}
+
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     (rangeText, rangeB) <- over _2 (fromMaybe $ regionOfB Line) <$> P.match Common.parseRange
-    void $ P.try (P.string "substitute") <|> P.string "s"
+    P.char 's' *> 
+      skipOptional (P.string "ub" *> skipOptional (P.string "stitute"))
+      P.<?> "substitute"
     delimiter <- P.satisfy (`elem` ("!@#$%^&*()[]{}<>/.,~';:?-=" :: String))
     from <- R.fromString <$> P.many' (P.satisfy (/= delimiter))
     void $ P.char delimiter

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Substitute.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Substitute.hs
@@ -47,8 +47,8 @@ parse = Common.parse $ do
     from <- R.fromString <$> P.many' (P.satisfy (/= delimiter))
     void $ P.char delimiter
     to <- R.fromString <$> P.many' (P.satisfy (/= delimiter))
-    void $ P.char delimiter
-    flagChars <- P.many' (P.satisfy $ P.inClass "gic")
+    flagChars <- P.option "" $
+      P.char delimiter *> P.many' (P.satisfy $ P.inClass "gic")
     return $! substitute from to delimiter
         ('g' `elem` flagChars)
         ('i' `elem` flagChars)

--- a/yi-keymap-vim/tests/vimtests/ex/s/8.test
+++ b/yi-keymap-vim/tests/vimtests/ex/s/8.test
@@ -1,0 +1,12 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(2,1)
+foo
+car
+baz
+-- Events
+j:s/b/c<CR>


### PR DESCRIPTION
This fixes two problems with the substitute ex command.

1. Vim supports another abbreviation `:sub`.
2. In vim you can omit the trailing delimiter if you don't need to pass any flags like so: `:s/x/y`.