### PR TITLE
Various fixes regarding ex ranges

### DIFF
--- a/yi-keymap-vim/8.test
+++ b/yi-keymap-vim/8.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+baz
+-- Events
+lvj:d<CR>

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Common.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Common.hs
@@ -164,11 +164,11 @@ parseLinePoint = parseCurrentLinePoint <|> parseNormalLinePoint
 -- | Parses .+-k
 parseCurrentLinePoint :: P.Parser (BufferM Point)
 parseCurrentLinePoint = do
-    void $ P.char '.'
-    relative <- P.option Nothing $ Just <$> do
-        c <- P.satisfy $ P.inClass "+-"
-        (i :: Int) <- read <$> P.many1 P.digit
-        return $ if c == '+' then i else -i
+    relative <- (Nothing <$ P.char '.' <|>) $
+      do () <$ P.char '.' <|> pure ()
+         c <- P.satisfy $ P.inClass "+-"
+         (i :: Int) <- read <$> P.many1 P.digit
+         return . Just $ if c == '+' then i else -i
     case relative of
         Nothing -> return $ pointB >>= solPointB
         Just offset -> return $ do

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Common.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Common.hs
@@ -109,9 +109,8 @@ parseRange = fmap Just parseFullRange
 
 styleRange :: P.Parser (BufferM Region) -> P.Parser (BufferM Region)
 styleRange = fmap $ \regionB -> do
-    style <- getRegionStyle
     region <- regionB
-    convertRegionToStyleB region style
+    convertRegionToStyleB region LineWise
 
 parseFullRange :: P.Parser (BufferM Region)
 parseFullRange = P.char '%' *> return (regionOfB Document)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Delete.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Delete.hs
@@ -12,20 +12,24 @@ module Yi.Keymap.Vim.Ex.Commands.Delete (parse) where
 
 import           Control.Applicative              (Alternative ((<|>)))
 import           Control.Monad                    (void)
+import qualified Data.Attoparsec.Text             as P (string, try, match)
+import           Data.Maybe                       (fromMaybe)
 import           Data.Text                        ()
-import qualified Data.Attoparsec.Text             as P (string, try)
+import           Data.Semigroup                   ((<>))
+import           Lens.Micro.Platform
 import           Yi.Buffer.Adjusted               hiding (Delete)
 import           Yi.Keymap                        (Action (BufferA))
 import           Yi.Keymap.Vim.Common             (EventString)
-import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (parse, pureExCommand)
+import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (parse, pureExCommand, parseRange)
 import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow))
 
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
+    (rangeText, rangeB) <- over _2 (fromMaybe currentLineRegionB) 
+      <$> P.match Common.parseRange
     void $ P.try ( P.string "delete") <|> P.string "d"
     return $ Common.pureExCommand {
-        cmdShow = "delete"
-      , cmdAction = BufferA $ do
-            deleteUnitB Line Forward
-            deleteN 1
+        cmdShow = rangeText <> "delete"
+      , cmdAction = BufferA $ deleteRegionB =<< rangeB
       }
+  where currentLineRegionB = flip convertRegionToStyleB LineWise =<< regionOfB Line

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Sort.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Sort.hs
@@ -38,4 +38,4 @@ sortA r = do
     region <- case r of
         Nothing -> regionOfB Document
         Just r' -> r'
-    sortLinesWithRegion region
+    sortLinesWithRegion region{regionEnd = regionEnd region - 1}

--- a/yi-keymap-vim/tests/vimtests/ex/d/3.test
+++ b/yi-keymap-vim/tests/vimtests/ex/d/3.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+
+-- Events
+:%d<CR>

--- a/yi-keymap-vim/tests/vimtests/ex/d/4.test
+++ b/yi-keymap-vim/tests/vimtests/ex/d/4.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+baz
+-- Events
+:1,2d<CR>

--- a/yi-keymap-vim/tests/vimtests/ex/d/5.test
+++ b/yi-keymap-vim/tests/vimtests/ex/d/5.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+
+-- Events
+j:-1,+1d<CR>

--- a/yi-keymap-vim/tests/vimtests/ex/d/6.test
+++ b/yi-keymap-vim/tests/vimtests/ex/d/6.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+baz
+-- Events
+j:-1,.d<CR>

--- a/yi-keymap-vim/tests/vimtests/ex/d/7.test
+++ b/yi-keymap-vim/tests/vimtests/ex/d/7.test
@@ -1,0 +1,10 @@
+-- Input
+(1,1)
+foo
+bar
+baz
+-- Output
+(1,1)
+baz
+-- Events
+Vj:d<CR>


### PR DESCRIPTION
This fixes a few problems regarding ex ranges:

1. Ex ranges are always linewise. Meaning a command like `:'<,'>d` will delete the whole lines of the selection not just the selected parts. I guess it is debatable whether we want to adopt this behaviour, but in any case relative ranges like `:-1,+1d` should be linewise, so if we decide against this the code for parsing those needs adjustment.
2. `:d` is now able to take a range. Not that I ever use this command, I just noticed it when I wanted to write tests for the new range behaviour.
3. In vim you can write for example `:-1,+1d` but `yi` required you to write `:.-1,.+1d`. This is what I was originally trying to fix.