### PR TITLE
Improve BufferM memory usage

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
 with pkgs;
-let ghc = haskell.packages.ghc801.ghcWithPackages (pkgs: [pkgs.gtk2hs-buildtools]);
+let ghc = haskell.packages.ghc802.ghcWithPackages (pkgs: [pkgs.gtk2hs-buildtools]);
 in
 
 stdenv.mkDerivation {

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
 - optparse-applicative-0.13.0.0
 - vty-5.13
 - ListLike-4.5
-resolver: nightly-2016-10-21
+resolver: lts-8.6
 build:
  library-profiling: true
  executable-profiling: false

--- a/yi-core/bench/Bench.hs
+++ b/yi-core/bench/Bench.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE BangPatterns              #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# OPTIONS_GHC -fno-warn-orphans      #-}
+module Main where
+
+import           Control.DeepSeq
+import           Control.Monad
+import           Criterion
+import           Criterion.Main hiding (defaultConfig)
+import qualified Data.List as L
+import           System.Environment
+import           System.IO
+import           Text.Printf (printf)
+import           Yi.Buffer
+import           Yi.Config (Config)
+import           Yi.Config.Default (defaultConfig)
+import           Yi.Editor
+import qualified Yi.Rope as R
+
+-- bogus instance
+instance NFData Editor where
+  rnf !_ = ()
+
+data EditorAction = forall a b. (NFData a, NFData b) =>
+  EditorAction
+    { _ea_act :: b -> EditorM a
+    , _ea_report :: a -> IO ()
+    , _ea_setup :: EditorM b
+    , _ea_name :: String
+    , _ea_config :: Config
+    }
+
+simpleAction :: String -> EditorM () -> EditorAction
+simpleAction n act = EditorAction
+  { _ea_act = \() -> act
+  , _ea_report = \() -> return ()
+  , _ea_name = n
+  , _ea_config = defaultConfig
+  , _ea_setup = return ()
+  }
+
+insertN :: Int -> EditorAction
+insertN !n = EditorAction
+  { _ea_act = \() -> do
+     runLoop
+  , _ea_report = \yis_l ->
+      putStrLn $ printf "Buffer has %d characters." yis_l
+
+  , _ea_name = "insert" ++ show n
+  , _ea_config = defaultConfig
+  , _ea_setup = return ()
+  }
+  where
+    spin n' | n' <= 0 = R.length <$> elemsB
+            | otherwise = do
+                insertB 'X'
+                spin $! n' - 1
+    runLoop = withCurrentBuffer $ spin n
+
+acts :: [EditorAction]
+acts = [ simpleAction "split20" $ replicateM_ 20 splitE
+       , simpleAction "newTab20" (replicateM_ 20 newTabE)
+       , Main.insertN 10
+       , Main.insertN 100
+       , Main.insertN 1000
+       , Main.insertN 100000
+       , Main.insertN 1000000
+       ]
+
+benchEditor :: (NFData a, NFData b)
+            => String -- ^ Benchmark name
+            -> Config -- ^ Config
+            -> EditorM a -- ^ Setup
+            -> (a -> EditorM b) -- ^ Action
+            -> Benchmark
+benchEditor bname c setup act =
+  env (return $! runEditor c setup emptyEditor) $ \ ~(setupEditor, a) -> do
+    bench bname $ nf (\a' -> snd $ runEditor c (act a') setupEditor) a
+
+main :: IO ()
+main = getArgs >>= \case
+  ["list_actions"] -> print $ map _ea_name acts
+  ["run_action", action_name] -> case L.find ((action_name ==) . _ea_name) acts of
+    Just EditorAction{..} ->
+      let !(!_, b) = runEditor _ea_config (_ea_setup >>= _ea_act) emptyEditor
+      in do
+        _ea_report b
+        putStrLn $ _ea_name  ++ " finished."
+    _ -> do
+      hPutStrLn stderr $ "No such action: " ++ action_name
+      hPutStrLn stderr $ "Available actions: " ++ show (map _ea_name acts)
+  _ -> do
+    let benchmarks :: [Benchmark]
+        benchmarks = flip map acts $ \EditorAction{..} ->
+          benchEditor _ea_name _ea_config _ea_setup _ea_act
+    defaultMain benchmarks

--- a/yi-core/package.yaml
+++ b/yi-core/package.yaml
@@ -186,3 +186,13 @@ tests:
       - yi-core
       - text
       - containers
+
+benchmarks:
+  all:
+    main: Bench.hs
+    source-dirs: bench
+    ghc-options: -Wall -ferror-spans -rtsopts
+    dependencies:
+      - yi-core
+      - criterion
+      - deepseq

--- a/yi-core/src/Yi/Config/Default.hs
+++ b/yi-core/src/Yi/Config/Default.hs
@@ -96,15 +96,15 @@ defaultConfig =
            , configTheme = defaultTheme
            }
          , defaultKm        = modelessKeymapSet nilKeymap
-         , startActions     = []
-         , initialActions   = []
+         , startActions     = mempty
+         , initialActions   = mempty
          , modeTable = [AnyMode fundamentalMode]
          , debugMode = False
          , configKillringAccumulate = False
          , configCheckExternalChangesObsessively = True
          , configRegionStyle = Exclusive
          , configInputPreprocess = I.idAutomaton
-         , bufferUpdateHandler = []
+         , bufferUpdateHandler = mempty
          , layoutManagers = [hPairNStack 1, vPairNStack 1, tall, wide]
          , configVars = mempty
          }

--- a/yi-core/src/Yi/Config/Simple.hs
+++ b/yi-core/src/Yi/Config/Simple.hs
@@ -118,6 +118,7 @@ module Yi.Config.Simple (
 import           Lens.Micro.Platform (Lens', (%=), (%~), use, lens)
 import           Control.Monad.State hiding (modify, get)
 import qualified Data.Text as T
+import qualified Data.Sequence as S
 import           Text.Printf(printf)
 import           Yi.Boot
 import           Yi.Buffer hiding (modifyMode)
@@ -372,5 +373,5 @@ killringAccumulate :: Field Bool
 killringAccumulate = configKillringAccumulateA
 
 -- | ?
-bufferUpdateHandler :: Field [[Update] -> BufferM ()]
+bufferUpdateHandler :: Field (S.Seq (S.Seq Update -> BufferM ()))
 bufferUpdateHandler = bufferUpdateHandlerA

--- a/yi-core/src/Yi/Core.hs
+++ b/yi-core/src/Yi/Core.hs
@@ -46,9 +46,8 @@ module Yi.Core
 
 import           Prelude                        hiding (elem, mapM_, or)
 
-import           Control.Concurrent             (ThreadId, forkIO, forkOS,
-                                                 modifyMVar, modifyMVar_,
-                                                 newMVar, readMVar, threadDelay)
+import           Control.Concurrent             (forkOS, modifyMVar, modifyMVar_
+                                                ,newMVar, readMVar, threadDelay)
 import           Control.Exc                    (ignoringException)
 import           Control.Exception              (SomeException, handle)
 import           Lens.Micro.Platform            (mapped, use, view, (%=), (%~),
@@ -65,7 +64,7 @@ import qualified Data.List.PointedList.Circular as PL (PointedList (_focus), len
 import           Data.List.Split                (splitOn)
 import qualified Data.Map                       as M (assocs, delete, empty, fromList, insert, member)
 import           Data.Maybe                     (fromMaybe, isNothing)
-import           Data.Monoid                    (First (First, getFirst), (<>))
+import           Data.Monoid                    (First (First, getFirst), (<>), mempty)
 import qualified Data.Text                      as T (Text, pack, unwords)
 import           Data.Time                      (getCurrentTime)
 import           Data.Time.Clock.POSIX          (posixSecondsToUTCTime)
@@ -320,8 +319,8 @@ refreshEditor = onYiVar $ \yi var -> do
         -- Terminate stale processes.
         terminateSubprocesses (staleProcess $ buffers e7) yi var {yiEditor = e7}
   where
-    clearUpdates = pendingUpdatesA .~ []
-    clearFollow = pointFollowsWindowA .~ const False
+    clearUpdates = pendingUpdatesA .~ mempty
+    clearFollow = pointFollowsWindowA .~ mempty
     -- Is this process stale? (associated with a deleted buffer)
     staleProcess bs p = not (bufRef p `M.member` bs)
 

--- a/yi-core/src/Yi/KillRing.hs
+++ b/yi-core/src/Yi/KillRing.hs
@@ -34,10 +34,10 @@ import           Yi.Buffer.Basic     (Direction (..))
 import qualified Yi.Rope             as R (YiString, length)
 
 
-data Killring = Killring { _krKilled :: Bool
-                         , _krAccumulate :: Bool
-                         , _krContents :: NonEmpty R.YiString
-                         , _krLastYank :: Bool
+data Killring = Killring { _krKilled :: !Bool
+                         , _krAccumulate :: !Bool
+                         , _krContents :: !(NonEmpty R.YiString)
+                         , _krLastYank :: !Bool
                          } deriving (Show, Eq)
 
 instance Binary Killring where


### PR DESCRIPTION
We take a small performance hit on operations (due to forcingn Undo) but
performance can be fixed there by not doing silly things. On the other
hand we have 5x+ memory improvement and we aren't leaking everywhere
anymore.

BufferM simple state chain update before/after
----------------------
http://i.imgur.com/F5IvX33.png (WriterT leak)

Basic benchmark, old
----------------------
insert 1million
http://heap.ezyang.com/view/832fbfa170d6741aef9eb56ed60ea5947026b979

yi-core-0.13.5: Benchmark running disabled by --no-run-benchmarks flag.
Completed 2 action(s).
benchmarking split20
time                 913.6 ns   (913.4 ns .. 913.9 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 913.9 ns   (913.6 ns .. 914.2 ns)
std dev              1.004 ns   (759.4 ps .. 1.431 ns)

benchmarking newTab20
time                 923.6 ns   (922.9 ns .. 924.2 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 922.5 ns   (922.0 ns .. 923.1 ns)
std dev              1.860 ns   (1.441 ns .. 2.453 ns)

benchmarking insert10
time                 36.89 μs   (36.88 μs .. 36.91 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 36.91 μs   (36.90 μs .. 36.94 μs)
std dev              66.81 ns   (45.80 ns .. 94.41 ns)

benchmarking insert100
time                 546.9 μs   (546.1 μs .. 547.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 547.3 μs   (546.4 μs .. 548.4 μs)
std dev              3.246 μs   (2.503 μs .. 4.405 μs)

benchmarking insert1000
time                 5.429 ms   (5.406 ms .. 5.449 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.419 ms   (5.402 ms .. 5.435 ms)
std dev              50.83 μs   (41.14 μs .. 66.15 μs)

benchmarking insert100000
time                 536.4 ms   (525.0 ms .. 542.0 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 539.6 ms   (539.0 ms .. 540.0 ms)
std dev              590.7 μs   (0.0 s .. 682.1 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking insert1000000
time                 5.154 s    (4.564 s .. 5.724 s)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 5.360 s    (5.237 s .. 5.573 s)
std dev              185.3 ms   (0.0 s .. 194.2 ms)
variance introduced by outliers: 19% (moderately inflated)

Basic benchmark, new
----------------------
http://heap.ezyang.com/view/a9bab4ab55cbeebfce21026c03ecba14a8ee2ba5

yi-core-0.13.5: Benchmark running disabled by --no-run-benchmarks flag.
benchmarking split20
time                 10.84 μs   (10.84 μs .. 10.85 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.84 μs   (10.84 μs .. 10.84 μs)
std dev              13.02 ns   (9.480 ns .. 19.48 ns)

benchmarking newTab20
time                 16.17 μs   (16.08 μs .. 16.27 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.16 μs   (16.10 μs .. 16.22 μs)
std dev              195.7 ns   (173.8 ns .. 224.7 ns)

benchmarking insert10
time                 66.12 μs   (66.04 μs .. 66.22 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 66.27 μs   (66.19 μs .. 66.47 μs)
std dev              424.4 ns   (190.1 ns .. 754.8 ns)

benchmarking insert100
time                 624.2 μs   (622.7 μs .. 625.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 626.7 μs   (625.1 μs .. 629.2 μs)
std dev              6.789 μs   (4.319 μs .. 11.23 μs)

benchmarking insert1000
time                 6.217 ms   (6.199 ms .. 6.231 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.199 ms   (6.184 ms .. 6.213 ms)
std dev              42.14 μs   (32.90 μs .. 59.21 μs)

benchmarking insert100000
time                 651.7 ms   (648.4 ms .. 654.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 654.5 ms   (653.9 ms .. 654.9 ms)
std dev              579.3 μs   (0.0 s .. 613.7 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking insert1000000
time                 6.572 s    (6.402 s .. 6.713 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.549 s    (6.505 s .. 6.573 s)
std dev              38.63 ms   (0.0 s .. 40.00 ms)
variance introduced by outliers: 19% (moderately inflated)