### PR TITLE
Fixed parser for ":!" vim command

### DIFF
--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Shell.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Shell.hs
@@ -12,7 +12,7 @@ module Yi.Keymap.Vim.Ex.Commands.Shell (parse) where
 
 import           Control.Monad                    (void)
 import qualified Data.Text                        as T (pack)
-import qualified Data.Attoparsec.Text             as P (char, many1)
+import qualified Data.Attoparsec.Text             as P (char,many1,satisfy)
 import           Yi.Command                       (buildRun)
 import           Yi.Keymap                        (Action (YiA))
 import           Yi.Keymap.Vim.Common             (EventString)
@@ -22,7 +22,7 @@ import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
     void $ P.char '!'
-    cmd <- T.pack <$> P.many1 (P.char ' ')
+    cmd <- T.pack <$> P.many1 (P.satisfy  (/=' '))
     args <- Common.commandArgs
     return $ Common.impureExCommand {
         cmdShow = "!"


### PR DESCRIPTION
The previous revision only allowed executing shell commands where the command name consists entirely of the space character.