### PR TITLE
:bdelete vim command takes argument for which buffer to delete

### DIFF
--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/BufferDelete.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/BufferDelete.hs
@@ -10,20 +10,42 @@
 
 module Yi.Keymap.Vim.Ex.Commands.BufferDelete (parse) where
 
-import           Control.Applicative              (Alternative ((<|>)))
+import           Control.Applicative              (Alternative ((<|>),some))
 import           Control.Monad                    (void)
-import           Data.Text                        ()
-import qualified Data.Attoparsec.Text             as P (string, try)
-import           Yi.Editor                        (closeBufferAndWindowE)
+import           Control.Monad.State              (gets)
+import qualified Data.Text                        as T (null)
+import qualified Data.Attoparsec.Text             as P (Parser, char, choice, digit, endOfInput, parseOnly, string, try)
+import           Yi.Buffer.Basic                  (BufferRef (..))
+import           Yi.Editor                        (closeBufferAndWindowE,deleteBuffer,getBufferWithName)
 import           Yi.Keymap                        (Action (EditorA))
 import           Yi.Keymap.Vim.Common             (EventString)
 import qualified Yi.Keymap.Vim.Ex.Commands.Common as Common (parse, pureExCommand)
+import           Yi.Keymap.Vim.Ex.Commands.Buffer (bufferIdentifier)
 import           Yi.Keymap.Vim.Ex.Types           (ExCommand (cmdAction, cmdShow))
 
 parse :: EventString -> Maybe ExCommand
 parse = Common.parse $ do
-    void $ P.try ( P.string "bdelete") <|> P.try ( P.string "bdel") <|> P.try (P.string "bd")
-    return $ Common.pureExCommand {
-        cmdShow = "bdelete"
-      , cmdAction = EditorA closeBufferAndWindowE
-      }
+    nameParser <* ((void $ some (P.char ' ')) <|> P.endOfInput)
+    bufIdent <- bufferIdentifier
+    if T.null bufIdent
+        then return $ Common.pureExCommand {
+            cmdShow = "bdelete"
+          , cmdAction = EditorA closeBufferAndWindowE
+          }
+        -- If a different buffer is specified: the user probably doesn't
+        -- want to close the current window. Also keep the current window
+        -- open if the current buffer is specified because otherwise there's
+        -- no way to do it.
+        else return $ Common.pureExCommand {
+            cmdShow = "bdelete"
+          , cmdAction = EditorA $ do
+                buffer <- case P.parseOnly bufferRef bufIdent of
+                    Right ref -> return ref
+                    Left _ -> getBufferWithName bufIdent
+                deleteBuffer buffer
+          }
+  where
+    bufferRef = BufferRef . read <$> some P.digit
+
+nameParser :: P.Parser ()
+nameParser = void . P.choice . fmap P.string $ ["bdelete","bdel","bd"]


### PR DESCRIPTION
Previous:
:bdelete ignores the argument, closes the current window if there's another one open.
Version in pull request:
:bdelete with no arguments preserves previous behavior, :bdelete with an argument closes the specified buffer but does not close any windows. This is closer to Vim, but in Vim :bdelete never closes any windows.