### PR TITLE
Fix #1041: Python syntax highlighting for multiline strings

### DIFF
--- a/yi-misc-modes/src/Yi/Lexer/Python.x
+++ b/yi-misc-modes/src/Yi/Lexer/Python.x
@@ -150,12 +150,16 @@ main :-
 }
 
 <doubledoc> {
-  \" \" \"                                      { m (const Base) stringStyle }
+  \"\"\"                                        { m (const Base) stringStyle }
+  $white+                                       ; -- whitespace
+  [^\"]+                                        { c stringStyle }
   .                                             { c stringStyle }
 }
 
 <singledoc> {
-  \' \' \'                                      { m (const Base) stringStyle }
+  \'\'\'                                        { m (const Base) stringStyle }
+  $white+                                       ; -- whitespace
+  [^\']+                                        { c stringStyle }
   .                                             { c stringStyle }
 }
 


### PR DESCRIPTION
Let me know if there's a better way to test this. Here are some screenshots to show you what I've been seeing:

Prior behavior:
![2017-09-28-borked](https://user-images.githubusercontent.com/1694705/30983702-2f8997e6-a459-11e7-8b94-26bed0f03245.png)

With this commit:
![2017-09-28-working](https://user-images.githubusercontent.com/1694705/30983728-3fd55054-a459-11e7-92bc-f575e9e9773c.png)

Notice, though, that quad-quotes will still break:
![2017-09-28-four-quotes](https://user-images.githubusercontent.com/1694705/30983761-52ce8e96-a459-11e7-903c-7e1651c4202b.png)

