### PR TITLE
[WIP] Dependency inversion

### DIFF
--- a/yi-ireader/yi-ireader.cabal
+++ b/yi-ireader/yi-ireader.cabal
@@ -25,12 +25,7 @@ library
     , data-default
     , microlens-platform
     , text
-    , yi-core >= 0.17
-    , yi-language >= 0.17
-    , yi-rope >= 0.10
   exposed-modules:
       Yi.Mode.IReader
       Yi.IReader
-  other-modules:
-      Paths_yi_ireader
   default-language: Haskell2010


### PR DESCRIPTION
I have started to think that the splitting of yi into separate packages might go easier if we make all packages indpendent of eachother and only allow them to communicate through very short and simple interface type classes. An example of my ideas is this pull request.

I think this way of programming allows the packages to be more easily changed. Right now there's a high change that you will cause one of the other packages to break if you make a change in yi-core. Only allowing each package to communicate via a small type class also makes the distinction between packages much more clear and force new code to be put in the right package.

What do you think? Is it too restrictive? Should typeclasses be used for this or should it just use records? I also haven't yet written a concrete implementation of `Yi` and `YiMode`, so maybe there are some mistakes in the type class definition.