### PR TITLE
Show line numbers in vty frontend

### DIFF
--- a/yi-core/src/Yi/Config/Default.hs
+++ b/yi-core/src/Yi/Config/Default.hs
@@ -94,6 +94,7 @@ defaultConfig =
            , configAutoHideTabBar = True
            , configWindowFill = ' '
            , configTheme = defaultTheme
+           , configLineNumbers = False
            }
          , defaultKm        = modelessKeymapSet nilKeymap
          , startActions     = mempty

--- a/yi-core/src/Yi/Config/Simple.hs
+++ b/yi-core/src/Yi/Config/Simple.hs
@@ -77,6 +77,7 @@ module Yi.Config.Simple (
   lineWrap,
   windowFill,
   theme,
+  lineNumbers,
   -- ** Layout
   layoutManagers,
   -- * Debugging
@@ -147,7 +148,7 @@ import           Yi.Config(Config, UIConfig, startFrontEndA, configUIA,
                            CursorStyle(..), configLeftSideScrollBarA,
                            configAutoHideScrollBarA, configAutoHideTabBarA,
                            configLineWrapA, configWindowFillA, configThemeA,
-                           layoutManagersA, configVarsA,
+                           layoutManagersA, configVarsA, configLineNumbersA
                            )
 
 
@@ -286,6 +287,10 @@ windowFill = configUIA . configWindowFillA
 -- | UI colour theme.
 theme :: Field Theme
 theme = configUIA . configThemeA
+
+-- | Line numbers.
+lineNumbers :: Field Bool
+lineNumbers = configUIA . configLineNumbersA
 
 ---------- Layout
 -- | List of registered layout managers. When cycling through layouts,

--- a/yi-core/src/Yi/Types.hs
+++ b/yi-core/src/Yi/Types.hs
@@ -394,7 +394,8 @@ data UIConfig = UIConfig {
    configWindowFill :: Char,
    -- ^ The char with which to fill empty window space.  Usually '~' for vi-like
    -- editors, ' ' for everything else.
-   configTheme :: Theme             -- ^ UI colours
+   configTheme :: Theme,            -- ^ UI colours
+   configLineNumbers :: Bool        -- ^ Should we show line numbers by default?
   }
 
 

--- a/yi-core/src/Yi/UI/LineNumbers.hs
+++ b/yi-core/src/Yi/UI/LineNumbers.hs
@@ -13,6 +13,7 @@
 
 module Yi.UI.LineNumbers
   ( DisplayLineNumbers (..)
+  , DisplayLineNumbersLocal (..)
   ) where
 
 import           Data.Binary    (Binary (..))
@@ -32,3 +33,17 @@ instance Default DisplayLineNumbers where
 instance Binary DisplayLineNumbers
 
 instance YiVariable DisplayLineNumbers
+
+-- | Like 'DisplayLineNumbers' but buffer-local.
+-- Nothing: use global settings
+-- Just True: display line numbers only in this buffer
+-- Just False: hide line numbers only in this buffer
+newtype DisplayLineNumbersLocal = DisplayLineNumbersLocal { getDisplayLineNumbersLocal :: Maybe Bool }
+  deriving (Generic, Typeable)
+
+instance Default DisplayLineNumbersLocal where
+  def = DisplayLineNumbersLocal Nothing
+
+instance Binary DisplayLineNumbersLocal
+
+instance YiVariable DisplayLineNumbersLocal

--- a/yi-core/src/Yi/UI/LineNumbers.hs
+++ b/yi-core/src/Yi/UI/LineNumbers.hs
@@ -12,9 +12,7 @@
 -- Line numbers.
 
 module Yi.UI.LineNumbers
-  ( getDisplayLineNumbers
-  , setDisplayLineNumbers
-  , getDisplayLineNumbersLocal
+  ( getDisplayLineNumbersLocal
   , setDisplayLineNumbersLocal
   ) where
 
@@ -23,28 +21,7 @@ import           Data.Default   (Default (..))
 import           Data.Typeable  (Typeable)
 import           GHC.Generics   (Generic)
 import           Yi.Buffer      (getBufferDyn, putBufferDyn)
-import           Yi.Editor      (getEditorDyn, putEditorDyn)
-import           Yi.Types       (BufferM, EditorM, YiVariable)
-
-newtype DisplayLineNumbers = DisplayLineNumbers { unDisplayLineNumbers :: Bool }
-  deriving (Generic, Typeable)
-
-instance Default DisplayLineNumbers where
-  def = DisplayLineNumbers False
-
-instance Binary DisplayLineNumbers
-
-instance YiVariable DisplayLineNumbers
-
--- | Get the global line number setting.
-getDisplayLineNumbers :: EditorM Bool
-getDisplayLineNumbers = unDisplayLineNumbers <$> getEditorDyn
-
--- | Set the global line number setting. Can be overridden by the buffer-local setting.
--- True: Show line numbers
--- False: Hide line numbers
-setDisplayLineNumbers :: Bool -> EditorM ()
-setDisplayLineNumbers = putEditorDyn . DisplayLineNumbers
+import           Yi.Types       (BufferM, YiVariable)
 
 newtype DisplayLineNumbersLocal = DisplayLineNumbersLocal { unDisplayLineNumbersLocal :: Maybe Bool }
   deriving (Generic, Typeable)

--- a/yi-core/src/Yi/UI/LineNumbers.hs
+++ b/yi-core/src/Yi/UI/LineNumbers.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module      :  Yi.UI.LineNumbers
+-- License     :  GPL-2
+-- Maintainer  :  yi-devel@googlegroups.com
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Line numbers.
+
+module Yi.UI.LineNumbers
+  ( DisplayLineNumbers (..)
+  ) where
+
+import           Data.Binary    (Binary (..))
+import           Data.Default   (Default (..))
+import           Data.Typeable  (Typeable)
+import           GHC.Generics   (Generic)
+import           Yi.Types       (YiVariable)
+
+-- | A YiVariable which globally toggles line numbers for frontends
+-- that support them.
+newtype DisplayLineNumbers = DisplayLineNumbers { getDisplayLineNumbers :: Bool }
+  deriving (Generic, Typeable)
+
+instance Default DisplayLineNumbers where
+  def = DisplayLineNumbers False
+
+instance Binary DisplayLineNumbers
+
+instance YiVariable DisplayLineNumbers

--- a/yi-core/yi-core.cabal
+++ b/yi-core/yi-core.cabal
@@ -123,6 +123,7 @@ library
       Yi.TextCompletion
       Yi.Types
       Yi.UI.Common
+      Yi.UI.LineNumbers
       Yi.UI.SimpleLayout
       Yi.UI.TabBar
       Yi.UI.Utils

--- a/yi-frontend-vty/src/Yi/Frontend/Vty.hs
+++ b/yi-frontend-vty/src/Yi/Frontend/Vty.hs
@@ -74,7 +74,7 @@ import           Yi.Types                       (YiConfigVariable)
 import qualified Yi.UI.Common                   as Common
 import qualified Yi.UI.SimpleLayout             as SL
 import           Yi.Layout                      (HasNeighborWest)
-import           Yi.UI.LineNumbers              (getDisplayLineNumbers, getDisplayLineNumbersLocal)
+import           Yi.UI.LineNumbers              (getDisplayLineNumbersLocal)
 import           Yi.UI.TabBar                   (TabDescr (TabDescr), tabBarDescr)
 import           Yi.UI.Utils                    (arrangeItems, attributesPictureAndSelB)
 import           Yi.Frontend.Vty.Conversions          (colorToAttr, fromVtyEvent)
@@ -260,9 +260,9 @@ renderWindow cfg' e (SL.Rect x y _ _) nb (win, focused) =
 
         notMini = not (isMini win)
         displayLineNumbers =
-          let local = withGivenBuffer (bufkey win) getDisplayLineNumbersLocal
-              global = getDisplayLineNumbers
-          in snd $ runEditor cfg' (fromMaybe <$> global <*> local) e
+          let local = snd $ runEditor cfg' (withGivenBuffer (bufkey win) getDisplayLineNumbersLocal) e
+              global = configLineNumbers cfg
+          in fromMaybe global local
 
         -- Collect some information for displaying line numbers
         (lineCount, _) = runBuffer win b lineCountB

--- a/yi-frontend-vty/src/Yi/Frontend/Vty.hs
+++ b/yi-frontend-vty/src/Yi/Frontend/Vty.hs
@@ -37,7 +37,7 @@ import           Data.Foldable                  (concatMap, toList)
 import           Data.IORef                     (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.List.PointedList.Circular as PL (PointedList (_focus), withFocus)
 import qualified Data.Map.Strict                as M ((!))
-import           Data.Maybe                     (maybeToList)
+import           Data.Maybe                     (fromMaybe, maybeToList)
 import           Data.Monoid                    (Endo (appEndo), (<>))
 import qualified Data.Text                      as T (Text, cons, empty,
                                                       justifyLeft, length, pack,
@@ -74,7 +74,7 @@ import           Yi.Types                       (YiConfigVariable)
 import qualified Yi.UI.Common                   as Common
 import qualified Yi.UI.SimpleLayout             as SL
 import           Yi.Layout                      (HasNeighborWest)
-import           Yi.UI.LineNumbers              (getDisplayLineNumbers)
+import           Yi.UI.LineNumbers              (getDisplayLineNumbers, getDisplayLineNumbersLocal)
 import           Yi.UI.TabBar                   (TabDescr (TabDescr), tabBarDescr)
 import           Yi.UI.Utils                    (arrangeItems, attributesPictureAndSelB)
 import           Yi.Frontend.Vty.Conversions          (colorToAttr, fromVtyEvent)
@@ -259,7 +259,10 @@ renderWindow cfg' e (SL.Rect x y _ _) nb (win, focused) =
         sty = configStyle cfg
 
         notMini = not (isMini win)
-        displayLineNumbers = getDisplayLineNumbers $ snd $ runEditor cfg' getEditorDyn e
+        displayLineNumbers =
+          let local = getDisplayLineNumbersLocal <$> withGivenBuffer (bufkey win) getBufferDyn
+              global = getDisplayLineNumbers <$> getEditorDyn
+          in snd $ runEditor cfg' (fromMaybe <$> global <*> local) e
 
         -- Collect some information for displaying line numbers
         (lineCount, _) = runBuffer win b lineCountB

--- a/yi-frontend-vty/src/Yi/Frontend/Vty.hs
+++ b/yi-frontend-vty/src/Yi/Frontend/Vty.hs
@@ -260,8 +260,8 @@ renderWindow cfg' e (SL.Rect x y _ _) nb (win, focused) =
 
         notMini = not (isMini win)
         displayLineNumbers =
-          let local = getDisplayLineNumbersLocal <$> withGivenBuffer (bufkey win) getBufferDyn
-              global = getDisplayLineNumbers <$> getEditorDyn
+          let local = withGivenBuffer (bufkey win) getDisplayLineNumbersLocal
+              global = getDisplayLineNumbers
           in snd $ runEditor cfg' (fromMaybe <$> global <*> local) e
 
         -- Collect some information for displaying line numbers

--- a/yi-keymap-vim/README.rst
+++ b/yi-keymap-vim/README.rst
@@ -29,6 +29,7 @@ Features incompatible with Vim because why not
   insert only "bar", but yi dot inserts "fobaro"
 * Scrolling motions (<C-f>, PageUp, etc) are treated like linewise motions.
 * <C-w>, <C-u> remove whole region, not only entered characters.
+* :set number is a buffer-local instead of a window-local setting.
 
 Testing
 =======

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex.hs
@@ -28,6 +28,7 @@ import qualified Yi.Keymap.Vim.Ex.Commands.GotoLine     as GotoLine (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Help         as Help (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Make         as Make (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Nohl         as Nohl (parse)
+import qualified Yi.Keymap.Vim.Ex.Commands.Number       as Number (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Paste        as Paste (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Quit         as Quit (parse)
 import qualified Yi.Keymap.Vim.Ex.Commands.Read         as Read (parse)
@@ -58,6 +59,7 @@ defExCommandParsers =
     , Help.parse
     , Make.parse
     , Nohl.parse
+    , Number.parse
     , Paste.parse
     , Quit.parse
     , Read.parse

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module      :  Yi.Keymap.Vim.Ex.Commands.Number
+-- License     :  GPL-2
+-- Maintainer  :  yi-devel@googlegroups.com
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Toggles line numbers.
+
+module Yi.Keymap.Vim.Ex.Commands.Number (parse) where
+
+import           Data.Monoid                      ((<>))
+import           Yi.Editor                        (getEditorDyn, printMsg, putEditorDyn)
+import           Yi.Keymap                        (Action (EditorA))
+import           Yi.Keymap.Vim.Common             (EventString)
+import           Yi.Keymap.Vim.Ex.Commands.Common (BoolOptionAction (..), parseBoolOption)
+import           Yi.Keymap.Vim.Ex.Types           (ExCommand)
+import           Yi.String                        (showT)
+import           Yi.UI.LineNumbers                (DisplayLineNumbers (..))
+
+parse :: EventString -> Maybe ExCommand
+parse = parseBoolOption "number" action
+
+action :: BoolOptionAction -> Action
+action BoolOptionAsk = EditorA $ do
+    value <- getDisplayLineNumbers <$> getEditorDyn
+    printMsg $ "number = " <> showT value
+action (BoolOptionSet b) = EditorA $ putEditorDyn (DisplayLineNumbers b)
+action BoolOptionInvert = EditorA $ do
+  x <- getDisplayLineNumbers <$> getEditorDyn
+  putEditorDyn (DisplayLineNumbers (not x))

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
@@ -12,23 +12,55 @@
 
 module Yi.Keymap.Vim.Ex.Commands.Number (parse) where
 
+import qualified Data.Attoparsec.Text             as P (string)
 import           Data.Monoid                      ((<>))
-import           Yi.Editor                        (getEditorDyn, printMsg, putEditorDyn)
-import           Yi.Keymap                        (Action (EditorA))
+import           Yi.Buffer                        (getBufferDyn, putBufferDyn)
+import           Yi.Editor                        (getEditorDyn, printMsg, putEditorDyn, withCurrentBuffer)
+import           Yi.Keymap                        (Action (BufferA, EditorA))
 import           Yi.Keymap.Vim.Common             (EventString)
-import           Yi.Keymap.Vim.Ex.Commands.Common (BoolOptionAction (..), parseBoolOption)
-import           Yi.Keymap.Vim.Ex.Types           (ExCommand)
+import           Yi.Keymap.Vim.Ex.Commands.Common (BoolOptionAction (..), parseBoolOption, pureExCommand)
+import qualified Yi.Keymap.Vim.Ex.Commands.Common as Ex (parse)
+import           Yi.Keymap.Vim.Ex.Types           (ExCommand (..), evStringToExCommand)
 import           Yi.String                        (showT)
-import           Yi.UI.LineNumbers                (DisplayLineNumbers (..))
+import           Yi.UI.LineNumbers                (DisplayLineNumbers (..), DisplayLineNumbersLocal (..))
 
+-- | Defines the following commands:
+-- - :set [no]number        (toggle buffer-local line numbers)
+-- - :set [no]globalnumber  (toggle global line numbers)
+-- - :unset number          (make the current buffer use the global setting)
 parse :: EventString -> Maybe ExCommand
-parse = parseBoolOption "number" action
+parse = evStringToExCommand
+  [ parseBoolOption "number" boolLocal
+  , parseBoolOption "globalnumber" boolGlobal
+  , parseUnset
+  ]
 
-action :: BoolOptionAction -> Action
-action BoolOptionAsk = EditorA $ do
-    value <- getDisplayLineNumbers <$> getEditorDyn
-    printMsg $ "number = " <> showT value
-action (BoolOptionSet b) = EditorA $ putEditorDyn (DisplayLineNumbers b)
-action BoolOptionInvert = EditorA $ do
-  x <- getDisplayLineNumbers <$> getEditorDyn
-  putEditorDyn (DisplayLineNumbers (not x))
+boolLocal :: BoolOptionAction -> Action
+boolLocal BoolOptionAsk = EditorA $ do
+  mb <- withCurrentBuffer (getDisplayLineNumbersLocal <$> getBufferDyn)
+  printMsg $ "number = " <> case mb of
+    Nothing -> "<unset>"
+    Just b  -> showT b
+boolLocal (BoolOptionSet b) = BufferA $
+  putBufferDyn (DisplayLineNumbersLocal (Just b))
+boolLocal BoolOptionInvert = BufferA $ do
+  b <- getDisplayLineNumbersLocal <$> getBufferDyn
+  putBufferDyn (DisplayLineNumbersLocal (fmap not b))
+
+boolGlobal :: BoolOptionAction -> Action
+boolGlobal BoolOptionAsk = EditorA $ do
+  b <- getDisplayLineNumbers <$> getEditorDyn
+  printMsg $ "globalnumber = " <> showT b
+boolGlobal (BoolOptionSet b) = EditorA $
+  putEditorDyn (DisplayLineNumbers b)
+boolGlobal BoolOptionInvert = EditorA $ do
+  b <- getDisplayLineNumbers <$> getEditorDyn
+  putEditorDyn (DisplayLineNumbers (not b))
+
+parseUnset :: EventString -> Maybe ExCommand
+parseUnset = Ex.parse $ do
+  _ <- P.string "unset number"
+  return $ pureExCommand
+    { cmdShow = "unset number"
+    , cmdAction = BufferA $ putBufferDyn (DisplayLineNumbersLocal Nothing)
+    }

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/Ex/Commands/Number.hs
@@ -14,15 +14,15 @@ module Yi.Keymap.Vim.Ex.Commands.Number (parse) where
 
 import qualified Data.Attoparsec.Text             as P (string)
 import           Data.Monoid                      ((<>))
-import           Yi.Buffer                        (getBufferDyn, putBufferDyn)
-import           Yi.Editor                        (getEditorDyn, printMsg, putEditorDyn, withCurrentBuffer)
+import           Yi.Editor                        (printMsg, withCurrentBuffer)
 import           Yi.Keymap                        (Action (BufferA, EditorA))
 import           Yi.Keymap.Vim.Common             (EventString)
 import           Yi.Keymap.Vim.Ex.Commands.Common (BoolOptionAction (..), parseBoolOption, pureExCommand)
 import qualified Yi.Keymap.Vim.Ex.Commands.Common as Ex (parse)
 import           Yi.Keymap.Vim.Ex.Types           (ExCommand (..), evStringToExCommand)
 import           Yi.String                        (showT)
-import           Yi.UI.LineNumbers                (DisplayLineNumbers (..), DisplayLineNumbersLocal (..))
+import           Yi.UI.LineNumbers                (getDisplayLineNumbers, setDisplayLineNumbers,
+                                                   getDisplayLineNumbersLocal, setDisplayLineNumbersLocal)
 
 -- | Defines the following commands:
 -- - :set [no]number        (toggle buffer-local line numbers)
@@ -37,30 +37,29 @@ parse = evStringToExCommand
 
 boolLocal :: BoolOptionAction -> Action
 boolLocal BoolOptionAsk = EditorA $ do
-  mb <- withCurrentBuffer (getDisplayLineNumbersLocal <$> getBufferDyn)
+  mb <- withCurrentBuffer getDisplayLineNumbersLocal
   printMsg $ "number = " <> case mb of
     Nothing -> "<unset>"
     Just b  -> showT b
-boolLocal (BoolOptionSet b) = BufferA $
-  putBufferDyn (DisplayLineNumbersLocal (Just b))
+boolLocal (BoolOptionSet b) = BufferA $ setDisplayLineNumbersLocal (Just b)
 boolLocal BoolOptionInvert = BufferA $ do
-  b <- getDisplayLineNumbersLocal <$> getBufferDyn
-  putBufferDyn (DisplayLineNumbersLocal (fmap not b))
+  b <- getDisplayLineNumbersLocal
+  setDisplayLineNumbersLocal (fmap not b)
 
 boolGlobal :: BoolOptionAction -> Action
 boolGlobal BoolOptionAsk = EditorA $ do
-  b <- getDisplayLineNumbers <$> getEditorDyn
+  b <- getDisplayLineNumbers
   printMsg $ "globalnumber = " <> showT b
 boolGlobal (BoolOptionSet b) = EditorA $
-  putEditorDyn (DisplayLineNumbers b)
+  setDisplayLineNumbers b
 boolGlobal BoolOptionInvert = EditorA $ do
-  b <- getDisplayLineNumbers <$> getEditorDyn
-  putEditorDyn (DisplayLineNumbers (not b))
+  b <- getDisplayLineNumbers
+  setDisplayLineNumbers (not b)
 
 parseUnset :: EventString -> Maybe ExCommand
 parseUnset = Ex.parse $ do
   _ <- P.string "unset number"
   return $ pureExCommand
     { cmdShow = "unset number"
-    , cmdAction = BufferA $ putBufferDyn (DisplayLineNumbersLocal Nothing)
+    , cmdAction = BufferA $ setDisplayLineNumbersLocal Nothing
     }

--- a/yi-keymap-vim/yi-keymap-vim.cabal
+++ b/yi-keymap-vim/yi-keymap-vim.cabal
@@ -89,6 +89,7 @@ library
       Yi.Keymap.Vim.Ex.Commands.Help
       Yi.Keymap.Vim.Ex.Commands.Make
       Yi.Keymap.Vim.Ex.Commands.Nohl
+      Yi.Keymap.Vim.Ex.Commands.Number
       Yi.Keymap.Vim.Ex.Commands.Paste
       Yi.Keymap.Vim.Ex.Commands.Quit
       Yi.Keymap.Vim.Ex.Commands.Read


### PR DESCRIPTION
Hello everyone!

This adds vim-style line numbers in vty frontend (as of #1054).

Currently it's not configurable (it displays line numbers for all non-mini windows), because I'm not exactly sure where to configure this. I think in vim, "number" is a property of the window but it can also be set globally, such that new windows are created with numbers on or off. So my guess would be to add fields to the Config and Window records and then create new windows with the number setting according to the number setting in Config.

Feedback appreciated :)