### PR TITLE
Ruby highlighter: slightly more correct symbol syntax

### DIFF
--- a/yi-misc-modes/src/Yi/Lexer/Ruby.x
+++ b/yi-misc-modes/src/Yi/Lexer/Ruby.x
@@ -182,7 +182,7 @@ main :-
    | @number \. @number? @exponent?             { c numberStyle }
 
  -- symbols and raw strings
- :[$small]+                                     { c stringStyle }
+ :[$small $large _]+                            { c stringStyle }
  \%q\{ @longstring* \}
  | \' @shortstring* \'                          { c stringStyle }
 


### PR DESCRIPTION
Previous behaviour: symbols such as `:abcDef` would be highlighted in two different colours. This patch highlights the entire symbol in a single colour.