### PR TITLE
Emacs-keymap undo units of work closely resembling the original

### DIFF
--- a/yi-core/src/Yi/Buffer/Misc.hs
+++ b/yi-core/src/Yi/Buffer/Misc.hs
@@ -186,6 +186,7 @@ module Yi.Buffer.Misc
   , startUpdateTransactionB
   , commitUpdateTransactionB
   , applyUpdate
+  , updateTransactionInFlightA
   , betweenB
   , decreaseFontSize
   , increaseFontSize

--- a/yi-keymap-emacs/yi-keymap-emacs.cabal
+++ b/yi-keymap-emacs/yi-keymap-emacs.cabal
@@ -19,7 +19,9 @@ library
   ghc-options: -Wall -ferror-spans
   build-depends:
       base >= 4.8 && < 5
+    , binary
     , containers
+    , data-default
     , filepath
     , Hclip
     , microlens-platform


### PR DESCRIPTION
Now we every 20 characters we commit a undo transaction. We also commit
when issuing a new emacs command.