### PR TITLE
Parse more stuff in .cabal

### DIFF
--- a/yi-misc-modes/src/Yi/Lexer/Cabal.x
+++ b/yi-misc-modes/src/Yi/Lexer/Cabal.x
@@ -50,13 +50,24 @@ $nl        = [\n\r]
 
 @reservedid =
    GPL
+  |GPL\-2
+  |GPL\-3
+  |AGPL
+  |AGPL\-3
   |LGPL
+  |LGPL\-2\.1
+  |LGPL\-3
   |BSD2
   |BSD3
   |BSD4
   |BSD\-2\-Clause
   |BSD\-3\-Clause
   |BSD\-4\-Clause
+  |MIT
+  |ISC
+  |MPL\-2\.0
+  |Apache
+  |Apache\-2\.0
   |PublicDomain
   |AllRightsReserved
   |OtherLicense

--- a/yi-misc-modes/src/Yi/Lexer/Cabal.x
+++ b/yi-misc-modes/src/Yi/Lexer/Cabal.x
@@ -51,8 +51,12 @@ $nl        = [\n\r]
 @reservedid =
    GPL
   |LGPL
+  |BSD2
   |BSD3
   |BSD4
+  |BSD\-2\-Clause
+  |BSD\-3\-Clause
+  |BSD\-4\-Clause
   |PublicDomain
   |AllRightsReserved
   |OtherLicense
@@ -80,6 +84,7 @@ $nl        = [\n\r]
   |[Dd]ata\-[Dd]ir
   |[Dd]ata\-[Ff]iles
   |[Dd]efault
+  |[Dd]efault\-[Ll]anguage
   |[Dd]escription
   |[Ee]xecutable
   |[Ee]xposed


### PR DESCRIPTION
The cabal lexer was lacking in the following two ways: 1, it was missing some of cabal 2.4's supported licenses (see https://github.com/haskell/cabal/blob/a650735caa241a2ae9ed544784d8583895d50ded/Cabal/Distribution/License.hs#L137), and 2. it didn't recognise the `default-language` library field. This PR fixes both issues. There's some other things that could be added but they're unrelated and I need to go to bed now. 