### PR TITLE
typo fixes

### DIFF
--- a/yi-intero/README.md
+++ b/yi-intero/README.md
@@ -65,7 +65,7 @@ This is now done!
 Difficulty: Easy
 
 > Intero needs to be installed in the current stack project, installing intero globally can lead
-> to problems as explained in the [TOOLING.md file of Intero](https://github.com/commercialhaskell/intero/blob/28271d50ca65c460cd0983cea13a2c4509b95583/TOOLING.md#installing). We can just run `stack build intero` everytime `interoStart` is used. That should be sufficient.
+> to problems as explained in the [TOOLING.md file of Intero](https://github.com/commercialhaskell/intero/blob/28271d50ca65c460cd0983cea13a2c4509b95583/TOOLING.md#installing). We can just run `stack build intero` every time `interoStart` is used. That should be sufficient.
 
 This is done! Right now the editor just freezes while installing intero and opening the project, when running `interoStart`. This should be changed so that a loading screen is shown in which the output of the currently running commands (like "stack build intero" and "stack ghci --with-ghc intero") is shown.
 

--- a/yi-keymap-emacs/src/Yi/Keymap/Emacs/Utils.hs
+++ b/yi-keymap-emacs/src/Yi/Keymap/Emacs/Utils.hs
@@ -411,7 +411,7 @@ visitTagTable act = do
 
 -- TODO: use TextUnit to count things inside region for better experience
 -- | Counts the number of lines, words and characters inside selected
--- region. Coresponds to emacs' @count-words-region@.
+-- region. Corresponds to emacs' @count-words-region@.
 countWordsRegion :: YiM ()
 countWordsRegion = do
   (l, w, c) <- withEditor $ do

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/NormalMap.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/NormalMap.hs
@@ -328,7 +328,7 @@ nonrepeatableBindings = fmap (mkBindingE Normal Drop)
     , ("zt", withCurrentBuffer scrollCursorToTopB, resetCount)
     , ("zb", withCurrentBuffer scrollCursorToBottomB, resetCount)
     , ("zz", withCurrentBuffer scrollToCursorB, resetCount)
-    {- -- TODO Horizantal scrolling
+    {- -- TODO Horizontal scrolling
     , ("ze", withCurrentBuffer .., resetCount)
     , ("zs", withCurrentBuffer .., resetCount)
     , ("zH", withCurrentBuffer .., resetCount)

--- a/yi-keymap-vim/src/Yi/Keymap/Vim/TextObject.hs
+++ b/yi-keymap-vim/src/Yi/Keymap/Vim/TextObject.hs
@@ -42,8 +42,8 @@ parseTextObject bs (c:[]) = fmap (TextObject Exclusive . ($ bs == OutsideBound))
     where mkUnit = lookup c
            [('w',  toOuter unitViWord unitViWordAnyBnd)
            ,('W',  toOuter unitViWORD unitViWORDAnyBnd)
-           ,('p',  toOuter unitEmacsParagraph unitEmacsParagraph) -- TODO inner could be inproved
-           ,('s',  toOuter unitSentence unitSentence) -- TODO inner could be inproved
+           ,('p',  toOuter unitEmacsParagraph unitEmacsParagraph) -- TODO inner could be improved
+           ,('s',  toOuter unitSentence unitSentence) -- TODO inner could be improved
            ,('"',  unitDelimited '"' '"')
            ,('`',  unitDelimited '`' '`')
            ,('\'', unitDelimited '\'' '\'')

--- a/yi-keymap-vim/tests/Generic/TestUtils.hs
+++ b/yi-keymap-vim/tests/Generic/TestUtils.hs
@@ -93,7 +93,7 @@ assertNotCurrentBuffer bufref editor =
 
 
 -- | Asserts that the current buffer is the expected buffer. The output will
--- contain the expected BufferKey and the acutal BufferKey of the current buffer.
+-- contain the expected BufferKey and the actual BufferKey of the current buffer.
 assertCurrentBuffer :: BufferRef -> Editor -> Assertion
 assertCurrentBuffer bufref editor =
     assertEqual "Unexpected current buffer" bufref (currentBuffer editor)

--- a/yi-language/src/Yi/Style.hs
+++ b/yi-language/src/Yi/Style.hs
@@ -98,7 +98,7 @@ data Color
     | Default
     -- ^ The system-default color of the engine used.
     -- e.g. in Gtk this should pick whatever the user has chosen as default color
-    -- (background or forground depending on usage) for the text.
+    -- (background or foreground depending on usage) for the text.
     deriving (Eq,Ord,Show)
 
 -- | Convert a color to its text specification, as to be accepted by XParseColor

--- a/yi-language/src/Yi/Syntax.hs
+++ b/yi-language/src/Yi/Syntax.hs
@@ -46,7 +46,7 @@ data Span a = Span {spanBegin :: !Point, spanContents :: !a, spanEnd :: !Point}
 -- the required functions, and is parametrized on the type of the internal
 -- state.
 
--- FIXME: this is actually completetly abstrcted from sytnax HL, so
+-- FIXME: this is actually completely abstracted from syntax HL, so
 -- the names are silly.
 
 data Highlighter cache syntax =
@@ -54,7 +54,7 @@ data Highlighter cache syntax =
         , hlRun :: Scanner Point Char -> Point -> cache -> cache
         , hlGetTree :: cache -> WindowRef -> syntax
         , hlFocus :: M.Map WindowRef Region -> cache -> cache
-        -- ^ focus at a given point, and return the coresponding node.
+        -- ^ focus at a given point, and return the corresponding node.
         -- (hint -- the root can always be returned, at the cost of
         -- performance.)
         }

--- a/yi-misc-modes/src/Yi/Lexer/GNUMake.x
+++ b/yi-misc-modes/src/Yi/Lexer/GNUMake.x
@@ -145,7 +145,7 @@ make :-
 
 -- After all the lines joined by a '\' character are appended together the text only undergoes
 -- variable expansion before being passed to the shell.
--- This means that a '#' character only indicates a comment *only* if the shell interpretting the
+-- This means that a '#' character only indicates a comment *only* if the shell interpreting the
 -- expanded text would consider it a comment. Wack huh?
 -- See 3.1
 <ruleCommand>

--- a/yi-misc-modes/src/Yi/Lexer/Perl.x
+++ b/yi-misc-modes/src/Yi/Lexer/Perl.x
@@ -172,7 +172,7 @@ perlHighlighterRules :-
 
     -- Matching regex quote-like operators are also kinda like interpolating strings.
     -- In order to prevent a / delimited regex quote from being confused with
-    -- division this only matches in the case the / is preeceded with the usual
+    -- division this only matches in the case the / is preceded with the usual
     -- context I use it.
     ^($white*)"/"
         { m (const $ HlInInterpString True "/" ) operatorStyle }
@@ -321,8 +321,8 @@ perlHighlighterRules :-
 }
 
 -- A heredoc identifier is collected until:
--- If there is no defined deliminating quote then the next non-identifier character
--- If there is a defined deliminating quote then the next character matching the specified
+-- If there is no defined delimiting quote then the next non-identifier character
+-- If there is a defined delimiting quote then the next character matching the specified
 -- character.
 -- TODO: Nested heredoc declarations
 <collectHeredocIdent>

--- a/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
+++ b/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
@@ -59,7 +59,7 @@ indentScanner = layoutHandler startsLayout [(Special '(', Special ')'),
 isBrace :: TT -> Bool
 isBrace (Tok br _ _) = Special '{' == br
 
--- | Theese are the tokens ignored by the layout handler.
+-- | These are the tokens ignored by the layout handler.
 ignoredToken :: TT -> Bool
 ignoredToken (Tok t _ (Posn{})) = isComment t || t == CppDirective
 
@@ -116,7 +116,7 @@ data Exp t
              }
       -- declaration
       -- declarations and parts of them follow
-    | Paren (PAtom t) [Exp t] (PAtom t) -- ^ A parenthesized, bracked or braced
+    | Paren (PAtom t) [Exp t] (PAtom t) -- ^ A parenthesized, bracketed or braced
     | Block [Exp t] -- ^ A block of things separated by layout
     | PAtom t [t] -- ^ An atom is a token followed by many comments
     | Expr [Exp t] -- ^
@@ -137,7 +137,7 @@ data Exp t
     | PGuard [PGuard t] -- ^ Righthandside of functions with |
       -- the PAtom in PGuard' does not contain any comments
     | PGuard' (PAtom t) (Exp t) (PAtom t)
-      -- type constructor is just a wrapper to indicate which highlightning to
+      -- type constructor is just a wrapper to indicate which highlighting to
       -- use.
     | TC (Exp t) -- ^ Type constructor
       -- data constructor same as with the TC constructor
@@ -324,7 +324,7 @@ pCAtom r c = PAtom <$> exact r <*> c
 
 pBareAtom a = pCAtom a pEmpty
 
--- | @pSepBy p sep@ parse /zero/ or more occurences of @p@, separated
+-- | @pSepBy p sep@ parse /zero/ or more occurrences of @p@, separated
 -- by @sep@, with optional ending @sep@,
 -- this is quite similar to the sepBy function provided in
 -- Parsec, but this one allows an optional extra separator at the end.

--- a/yi-snippet/README.rst
+++ b/yi-snippet/README.rst
@@ -68,7 +68,7 @@ The body can be written using `do` notation::
     _ <- place "OverloadedStrings"
     lit " #-}"
 
-Avaliable primitives are:
+Available primitives are:
 
 lit <text>
   just a piece of text


### PR DESCRIPTION
yi-intero/README.md
yi-keymap-emacs/src/Yi/Keymap/Emacs/Utils.hs
yi-keymap-vim/src/Yi/Keymap/Vim/NormalMap.hs
yi-keymap-vim/src/Yi/Keymap/Vim/TextObject.hs
yi-keymap-vim/tests/Generic/TestUtils.hs
yi-language/src/Yi/Style.hs
yi-language/src/Yi/Syntax.hs
yi-misc-modes/src/Yi/Lexer/GNUMake.x
yi-misc-modes/src/Yi/Lexer/Perl.x
yi-mode-haskell/src/Yi/Syntax/Haskell.hs
yi-snippet/README.rst

```sh
$ cat typos.sh
#!/bin/bash

sed -i "s/Avaliable/Available/g" yi/yi-snippet/README.rst
sed -i "s/Coresponds/Corresponds/g" yi/yi-keymap-emacs/src/Yi/Keymap/Emacs/Utils.hs
sed -i "s/Horizantal/Horizontal/g" yi/yi-keymap-vim/src/Yi/Keymap/Vim/NormalMap.hs
sed -i "s/Theese/These/g" yi/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
sed -i "s/abstrcted/abstracted/g" yi/yi-language/src/Yi/Syntax.hs
sed -i "s/acutal/actual/g" yi/yi-keymap-vim/tests/Generic/TestUtils.hs
sed -i "s/bracked/bracketed/g" yi/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
sed -i "s/completetly/completely/g" yi/yi-language/src/Yi/Syntax.hs
sed -i "s/coresponding/corresponding/g" yi/yi-language/src/Yi/Syntax.hs
sed -i "s/deliminating/delimiting/g" yi/yi-misc-modes/src/Yi/Lexer/Perl.x
sed -i "s/everytime/every time/g" yi/yi-intero/README.md
sed -i "s/forground/foreground/g" yi/yi-language/src/Yi/Style.hs
sed -i "s/highlightning/highlighting/g" yi/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
sed -i "s/inproved/improved/g" yi/yi-keymap-vim/src/Yi/Keymap/Vim/TextObject.hs
sed -i "s/interpretting/interpreting/g" yi/yi-misc-modes/src/Yi/Lexer/GNUMake.x
sed -i "s/occurences/occurrences/g" yi/yi-mode-haskell/src/Yi/Syntax/Haskell.hs
sed -i "s/preeceded/preceded/g" yi/yi-misc-modes/src/Yi/Lexer/Perl.x
sed -i "s/sytnax/syntax/g" yi/yi-language/src/Yi/Syntax.hs
$ 
```