### PR TITLE
Allow building with newer dependencies

### DIFF
--- a/yi-core/src/Yi/Dired.hs
+++ b/yi-core/src/Yi/Dired.hs
@@ -91,7 +91,12 @@ import           System.PosixCompat.Files (FileStatus, fileExist, fileGroup,
                                            unionFileModes)
 import           System.PosixCompat.Types (FileMode, GroupID, UserID)
 #ifndef mingw32_HOST_OS
+#if MIN_VERSION_unix(2,8,0)
+import           System.Posix.User.ByteString (GroupEntry(GroupEntry), UserEntry(UserEntry))
+import           System.Posix.User        (getAllGroupEntries,
+#else
 import           System.Posix.User        (GroupEntry(..), UserEntry(..),getAllGroupEntries,
+#endif
                                            getAllUserEntries,
                                            getGroupEntryForID,
                                            getUserEntryForID, groupID, userID, userName, groupName)

--- a/yi-frontend-pango/src/Yi/Frontend/Pango/Control.hs
+++ b/yi-frontend-pango/src/Yi/Frontend/Pango/Control.hs
@@ -84,7 +84,8 @@ import qualified Graphics.UI.Gtk as Gtk
 import qualified Graphics.UI.Gtk.Gdk.Events as Gdk.Events
 import System.Glib.GError
 import Control.Monad.Reader (ask, asks, MonadReader(..))
-import Control.Monad.State (ap, get, put, modify)
+import Control.Monad (ap)
+import Control.Monad.State (get, put, modify)
 import Control.Monad.Base
 import Control.Concurrent (newMVar, modifyMVar, MVar, newEmptyMVar, putMVar,
                            readMVar, isEmptyMVar)

--- a/yi-frontend-vty/yi-frontend-vty.cabal
+++ b/yi-frontend-vty/yi-frontend-vty.cabal
@@ -26,7 +26,7 @@ library
     , pointedlist
     , stm >= 2.2
     , text
-    , vty >= 5.4
+    , vty >= 5.4 && < 6
     , yi-core >= 0.19
     , yi-language >= 0.19
     , yi-rope >= 0.10

--- a/yi-language/src/Yi/Lexer/Compilation.x
+++ b/yi-language/src/Yi/Lexer/Compilation.x
@@ -24,13 +24,13 @@ tokens :-
      let Just (_before, arr, _after) = matchOnceText re $ map snd str
          re :: Regex
          re = makeRegex "^(.+):([0-9]+):([0-9]+):(.*)$"
-     in (st, Report (fst $ arr!1) (read $ fst $ arr!2) (read $ fst $ arr!3) (fst $ arr!4)) }
+     in (st, Report (fst $ arr Data.Array.! 1) (read $ fst $ arr Data.Array.! 2) (read $ fst $ arr Data.Array.! 3) (fst $ arr Data.Array.! 4)) }
  -- without a column number
  @file":" @number ":" .*\n  { \str st ->
      let Just (_before, arr, _after) = matchOnceText re $ map snd str
          re :: Regex
          re = makeRegex "^(.+):([0-9]+):(.*)$"
-     in (st, Report (fst $ arr!1) (read $ fst $ arr!2) 0 (fst $ arr!3)) }
+     in (st, Report (fst $ arr Data.Array.! 1) (read $ fst $ arr Data.Array.! 2) 0 (fst $ arr Data.Array.! 3)) }
 
  $white+                              ; -- unparseable stuff
  [^$white]+                           ;

--- a/yi-language/src/Yi/Lexer/common.hsinc
+++ b/yi-language/src/Yi/Lexer/common.hsinc
@@ -6,8 +6,8 @@
 
 #define IBOX(n) (I# (n))
 
-#define GEQ_(x, y) (tagToEnum# (x >=# y))
-#define EQ_(x, y) (tagToEnum# (x ==# y))
+#define GEQ_(x, y) (GHC.Exts.tagToEnum# (x >=# y))
+#define EQ_(x, y) (GHC.Exts.tagToEnum# (x ==# y))
 
 -- | Scan one token. Return (maybe) a token and a new state.
 alexScanToken :: (AlexState HlState, AlexInput) -> Maybe (Tok Token, (AlexState HlState, AlexInput))
@@ -37,7 +37,7 @@ alexScanUser' user input (I# (sc))
           Just _  -> (AlexError input', lookahead)
       (AlexLastSkip input'' len, _, lookahead) -> (AlexSkip input'' len, lookahead)
 #if MIN_TOOL_VERSION_alex(3,2,0)
-      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions ! k), lookahead)
+      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions Data.Array.! k), lookahead)
 #else
       (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len k, lookahead)
 #endif

--- a/yi-misc-modes/src/Yi/Lexer/common.hsinc
+++ b/yi-misc-modes/src/Yi/Lexer/common.hsinc
@@ -6,8 +6,8 @@
 
 #define IBOX(n) (I# (n))
 
-#define GEQ_(x, y) (tagToEnum# (x >=# y))
-#define EQ_(x, y) (tagToEnum# (x ==# y))
+#define GEQ_(x, y) (GHC.Exts.tagToEnum# (x >=# y))
+#define EQ_(x, y) (GHC.Exts.tagToEnum# (x ==# y))
 
 -- | Scan one token. Return (maybe) a token and a new state.
 alexScanToken :: (AlexState HlState, AlexInput) -> Maybe (Tok Token, (AlexState HlState, AlexInput))
@@ -37,7 +37,7 @@ alexScanUser' user input (I# (sc))
           Just _  -> (AlexError input', lookahead)
       (AlexLastSkip input'' len, _, lookahead) -> (AlexSkip input'' len, lookahead)
 #if MIN_TOOL_VERSION_alex(3,2,0)
-      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions ! k), lookahead)
+      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions Data.Array.! k), lookahead)
 #else
       (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len k, lookahead)
 #endif

--- a/yi-mode-haskell/src/Yi/Lexer/common.hsinc
+++ b/yi-mode-haskell/src/Yi/Lexer/common.hsinc
@@ -6,8 +6,8 @@
 
 #define IBOX(n) (I# (n))
 
-#define GEQ_(x, y) (tagToEnum# (x >=# y))
-#define EQ_(x, y) (tagToEnum# (x ==# y))
+#define GEQ_(x, y) (GHC.Exts.tagToEnum# (x >=# y))
+#define EQ_(x, y) (GHC.Exts.tagToEnum# (x ==# y))
 
 -- | Scan one token. Return (maybe) a token and a new state.
 alexScanToken :: (AlexState HlState, AlexInput) -> Maybe (Tok Token, (AlexState HlState, AlexInput))
@@ -37,7 +37,7 @@ alexScanUser' user input (I# (sc))
           Just _  -> (AlexError input', lookahead)
       (AlexLastSkip input'' len, _, lookahead) -> (AlexSkip input'' len, lookahead)
 #if MIN_TOOL_VERSION_alex(3,2,0)
-      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions ! k), lookahead)
+      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions Data.Array.! k), lookahead)
 #else
       (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len k, lookahead)
 #endif

--- a/yi-mode-javascript/src/Yi/Lexer/common.hsinc
+++ b/yi-mode-javascript/src/Yi/Lexer/common.hsinc
@@ -6,8 +6,8 @@
 
 #define IBOX(n) (I# (n))
 
-#define GEQ_(x, y) (tagToEnum# (x >=# y))
-#define EQ_(x, y) (tagToEnum# (x ==# y))
+#define GEQ_(x, y) (GHC.Exts.tagToEnum# (x >=# y))
+#define EQ_(x, y) (GHC.Exts.tagToEnum# (x ==# y))
 
 -- | Scan one token. Return (maybe) a token and a new state.
 alexScanToken :: (AlexState HlState, AlexInput) -> Maybe (Tok Token, (AlexState HlState, AlexInput))
@@ -37,7 +37,7 @@ alexScanUser' user input (I# (sc))
           Just _  -> (AlexError input', lookahead)
       (AlexLastSkip input'' len, _, lookahead) -> (AlexSkip input'' len, lookahead)
 #if MIN_TOOL_VERSION_alex(3,2,0)
-      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions ! k), lookahead)
+      (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len (alex_actions Data.Array.! k), lookahead)
 #else
       (AlexLastAcc k input'' len, _, lookahead) -> (AlexToken input'' len k, lookahead)
 #endif


### PR DESCRIPTION
This gets `cabal build all --allow-newer -c 'vty<6'` working on GHC 9.10.1.