### PR TITLE
Test.Tasty.Hspec stopped re-exporting Test.Hspec in tasty-hspec 1.1.7

### DIFF
--- a/yi-language/test/Spec.hs
+++ b/yi-language/test/Spec.hs
@@ -1,6 +1,7 @@
 
 import Data.Bifunctor (first)
 
+import Test.Hspec
 import Test.Tasty
 import Test.Tasty.Hspec
 import Test.Tasty.QuickCheck

--- a/yi-language/yi-language.cabal
+++ b/yi-language/yi-language.cabal
@@ -73,6 +73,7 @@ test-suite tasty
     , transformers-base
     , unordered-containers >= 0.1.3 && < 0.3
     , microlens-platform
+    , hspec
     , tasty
     , tasty-hspec
     , tasty-quickcheck


### PR DESCRIPTION
Fixes #1124.