### PR TITLE
Bump test dependency bounds to match those of the library itself

### DIFF
--- a/yi-language/yi-language.cabal
+++ b/yi-language/yi-language.cabal
@@ -68,8 +68,8 @@ test-suite tasty
     , containers
     , hashable >=1.1.2.5
     , pointedlist >= 0.5
-    , regex-base ==0.93.*
-    , regex-tdfa >= 1.1 && <1.3
+    , regex-base >=0.93 && <0.95
+    , regex-tdfa >= 1.1 && <1.4
     , transformers-base
     , unordered-containers >= 0.1.3 && < 0.3
     , microlens-platform


### PR DESCRIPTION
This is necessary for the yi-language tests to work on GHC 8.8.1 and above without needing to use allow-newer.